### PR TITLE
Migration 448 Collect data only from secondaries by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,11 @@
 
 ## Description
 dcrcli is a command-line utility to collect diagnostic information for MongoDB deployments:
-- **getMongoData** output for each node of the cluster.
-- **FTDC data** for each node of the cluster.
-- **Mongod Logs** from all nodes in the cluster.
+- **getMongoData** output for each selected node.
+- **FTDC data** for each selected node.
+- **Mongod Logs** from each selected node.
+
+By default, collection targets **one secondary** only (to avoid load on primaries). You can widen scope interactively or with a flag (see [Collection scope](#collection-scope-which-nodes)).
 
 This enables centralized diagnostics and faster troubleshooting across replica sets and sharded clusters.
 
@@ -15,6 +17,7 @@ This enables centralized diagnostics and faster troubleshooting across replica s
 - [Releases](#releases)
 - [Prerequisites](#prerequisites)
 - [Usage](#usage)
+  - [Collection scope (which nodes)](#collection-scope-which-nodes)
 - [Output Location](#output-location)
 - [Internal Notes](#internal-notes)
 - [Build from Source](#build-from-source)
@@ -39,7 +42,8 @@ For a successful collection, ensure the following before running dcrcli:
   - Allow SSH access from the dcrcli host to all nodes in the cluster.
 
 2) MongoDB Shell
-- Either the mongo or mongosh shell must be installed on the machine running dcrcli.
+- Either the **mongo** or **mongosh** shell must be installed on the machine running dcrcli.
+- **Use the latest mongosh** (current stable) and ensure it is on `PATH`. This is **strongly recommended**, especially for **sharded clusters** and whenever dcrcli must discover node roles (primary vs secondary). Newer mongosh emits reliable JSON for topology and role checks; the legacy **mongo** shell may not parse the same way, which can leave roles unknown and cause secondary-only collection to fail until you use **mongosh** or choose **all-nodes**.
 - If authentication is enabled:
   - Use a database user with the appropriate permissions (see “Minimum Required Permissions” in the getMongoData README: https://github.com/mongodb/support-tools/blob/master/getMongoData/README.md#more-details).
   - If the password contains special characters (e.g., $, /, ?, #), input them directly without percent encoding.
@@ -74,12 +78,38 @@ Follow these steps:
 chmod +x <binary-name>
 ```
 
-5. Run:
+4. Run:
 ```
 ./<binary-name>
 ```
 
-6. Follow the on-screen prompts to start data collection.
+5. Follow the on-screen prompts to start data collection (credentials, SSH user, then—after topology is found—which nodes to collect).
+
+### Collection scope (which nodes)
+After topology is discovered, dcrcli asks **which nodes to collect from** (unless you pass a flag). You can also pass:
+
+```
+./<binary-name> -collect-nodes=one-secondary
+./<binary-name> -collect-nodes=all-secondaries
+./<binary-name> -collect-nodes=all-nodes
+```
+
+Run `./<binary-name> -h` for a short summary of flags.
+
+- If **`-collect-nodes`** is set, it **overrides** the interactive menu (useful for scripts and CI).
+- If stdin is **not** a terminal (non-interactive), the default is **`one-secondary`** without prompting.
+
+| Value | Behavior |
+|-------|----------|
+| **one-secondary** | A **single** secondary member only (smallest footprint; no extra mongos/config added). |
+| **all-secondaries** | **Every** secondary (including config-server members that are secondaries). On a **sharded** topology, dcrcli also adds **one** mongos and **one** config-server `mongod` from `getShardMap` that are not already in that list (first of each when sorted by hostname/port). |
+| **all-nodes** | **Every** host dcrcli discovered: all shard `mongod`s (primaries and secondaries), **all** mongos, **all** config-server members. May add load on primaries; use for a full cluster capture. |
+
+**Sharded clusters:** Use a **mongos** as the seed host when possible (same as before). For **all-secondaries**, one router and one CSRS member are included when the topology is detected as sharded. **`getShardMap`** does not always list every mongos; the **seed mongos** is added to the list when missing (and may be the mongos chosen for option 2).
+
+**Replica sets (non-sharded):** **all-secondaries** and **one-secondary** only collect secondary `mongod` members; there is no separate mongos/config layer.
+
+**Standalone (single `mongod`):** If only **one** data node is discovered and it is **not** a secondary (normal for standalone), and you use options **1** or **2** without **`-collect-nodes`**, dcrcli prints a **WARNING** and asks whether to collect from that **primary** anyway (**y** / **yes** to continue). There is no extra prompt when you pass **`-collect-nodes`** or when stdin is not a terminal—use **`-collect-nodes=all-nodes`** for unattended standalone runs.
 
 Terminologies:
 
@@ -101,7 +131,8 @@ Terminologies:
 
 ## Internal Notes
 - [getMongoData](https://github.com/mongodb/support-tools/blob/master/getMongoData/README.md)
-  - dcrcli invokes the mongo or mongosh shell with a compatible getMongoData.js script. Ensure the shell is in PATH.
+  - dcrcli invokes the mongo or mongosh shell with a compatible getMongoData.js script. Ensure the shell is in PATH. **mongosh** is preferred for consistent JSON from topology commands (`hello`, `getShardMap`, role detection).
+- Node selection uses shell output to classify **PRIMARY**, **SECONDARY**, **MONGOS**, etc. Keep **mongosh** up to date for best results on sharded clusters.
 - [rsync](https://man7.org/linux/man-pages/man1/rsync.1.html)
   - For remote file copy tasks, dcrcli runs rsync with flags similar to:
     ```

--- a/archiver/archiver.go
+++ b/archiver/archiver.go
@@ -17,8 +17,10 @@ package archiver
 import (
 	"archive/tar"
 	"compress/gzip"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -40,6 +42,11 @@ func TarWithPatternMatch(src string, filepattern string, writers ...io.Writer) e
 
 	return filepath.Walk(src, func(file string, fi os.FileInfo, err error) error {
 		if err != nil {
+			// diagnostic.data/metrics.interim is recreated/removed by mongod while we walk; treat as non-fatal.
+			if errors.Is(err, fs.ErrNotExist) {
+				fmt.Println("WARNING: In archiving process skipping path removed during walk (e.g. metrics.interim):", err)
+				return nil
+			}
 			fmt.Println("ERROR: In archiving process", err)
 			return err
 		}
@@ -79,6 +86,10 @@ func TarWithPatternMatch(src string, filepattern string, writers ...io.Writer) e
 
 		f, err := os.Open(file)
 		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				fmt.Println("WARNING: In archiving process file disappeared before copy:", file)
+				return nil
+			}
 			fmt.Println("ERROR: In archiving process os.Open: ", err)
 			return err
 		}

--- a/collectnodes/collectnodes.go
+++ b/collectnodes/collectnodes.go
@@ -1,0 +1,269 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package collectnodes defines how many cluster members dcrcli collects from (secondaries-only vs all nodes).
+package collectnodes
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+
+	"dcrcli/topologyfinder"
+)
+
+// Mode controls which discovered nodes are included in data collection.
+type Mode int
+
+const (
+	// ModeOneSecondary collects from a single SECONDARY only (no mongos/config unless that node is a secondary).
+	ModeOneSecondary Mode = iota
+	// ModeAllSecondaries collects every SECONDARY; when the topology is sharded, also one mongos and one config server (deterministic by host/port sort).
+	ModeAllSecondaries
+	// ModeAllNodes collects every discovered node (shard primaries, secondaries, mongos, config, etc.).
+	ModeAllNodes
+)
+
+func (m Mode) String() string {
+	switch m {
+	case ModeOneSecondary:
+		return flagOneSecondary
+	case ModeAllSecondaries:
+		return flagAllSecondaries
+	case ModeAllNodes:
+		return flagAllNodes
+	default:
+		return "unknown"
+	}
+}
+
+// Description is a short human-readable summary for stdout (prompt confirmation and progress lines).
+func (m Mode) Description() string {
+	switch m {
+	case ModeOneSecondary:
+		return "one secondary only"
+	case ModeAllSecondaries:
+		return "all secondaries plus one mongos and one config server when sharded"
+	case ModeAllNodes:
+		return "all discovered nodes (every mongod primary/secondary, all mongos, all config members)"
+	default:
+		return m.String()
+	}
+}
+
+const (
+	flagOneSecondary    = "one-secondary"
+	flagAllSecondaries  = "all-secondaries"
+	flagAllNodes        = "all-nodes"
+)
+
+// ErrNoSecondaries is returned by Select for secondary-only modes when no node is classified as SECONDARY.
+var ErrNoSecondaries = errors.New("no SECONDARY members among discovered nodes")
+
+// ParseMode parses --collect-nodes flag values.
+func ParseMode(s string) (Mode, error) {
+	switch strings.TrimSpace(strings.ToLower(s)) {
+	case flagOneSecondary:
+		return ModeOneSecondary, nil
+	case flagAllSecondaries:
+		return ModeAllSecondaries, nil
+	case flagAllNodes:
+		return ModeAllNodes, nil
+	case "":
+		return 0, errors.New("collect-nodes value is empty")
+	default:
+		return 0, fmt.Errorf("invalid --collect-nodes value %q (want %s, %s, or %s)", s, flagOneSecondary, flagAllSecondaries, flagAllNodes)
+	}
+}
+
+// Prompt asks the user which collection scope to use.
+func Prompt(stdin io.Reader, stdout io.Writer) (Mode, error) {
+	reader := bufio.NewReader(stdin)
+	_, _ = fmt.Fprintln(stdout, "Choose which MongoDB nodes to collect from:")
+	_, _ = fmt.Fprintln(stdout, "  1) One secondary only (default)")
+	_, _ = fmt.Fprintln(stdout, "  2) All secondaries; if sharded, also one mongos and one config server")
+	_, _ = fmt.Fprintln(stdout, "  3) All discovered nodes (every mongod, all mongos, all config servers; may add load, storage usage)")
+	_, _ = fmt.Fprint(stdout, "Enter choice (1-3) [1]: ")
+
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return 0, err
+	}
+	line = strings.TrimSpace(strings.TrimSuffix(line, "\n"))
+	var mode Mode
+	switch {
+	case line == "" || line == "1":
+		mode = ModeOneSecondary
+	case line == "2":
+		mode = ModeAllSecondaries
+	case line == "3":
+		mode = ModeAllNodes
+	default:
+		return 0, fmt.Errorf("invalid choice %q: enter 1, 2, or 3", line)
+	}
+	if line == "" {
+		_, _ = fmt.Fprintf(stdout, "\nUsing default (1) — %s\n\n", mode.Description())
+	} else {
+		_, _ = fmt.Fprintf(stdout, "\nUsing choice %s — %s\n\n", line, mode.Description())
+	}
+	return mode, nil
+}
+
+// LooksLikeStandaloneMongod reports a single discovered data mongod (typical standalone: one host, not mongos/arbiter).
+func LooksLikeStandaloneMongod(nodes []topologyfinder.ClusterNode) bool {
+	if len(nodes) != 1 {
+		return false
+	}
+	r := strings.ToUpper(strings.TrimSpace(nodes[0].ReplicaState))
+	switch r {
+	case "MONGOS", "ARBITER":
+		return false
+	default:
+		return true
+	}
+}
+
+// StandalonePrimaryTargets returns the lone node for collection after the user opts into primary on standalone.
+func StandalonePrimaryTargets(nodes []topologyfinder.ClusterNode) []topologyfinder.ClusterNode {
+	if len(nodes) != 1 {
+		return nil
+	}
+	return []topologyfinder.ClusterNode{nodes[0]}
+}
+
+// PromptStandaloneCollectPrimary asks whether to collect from the standalone primary (y/N).
+func PromptStandaloneCollectPrimary(stdin io.Reader, stdout io.Writer) (bool, error) {
+	_, _ = fmt.Fprint(stdout, "Collect from this primary (standalone) anyway? [y/N]: ")
+	line, err := bufio.NewReader(stdin).ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+	s := strings.ToLower(strings.TrimSpace(strings.TrimSuffix(line, "\n")))
+	return s == "y" || s == "yes", nil
+}
+
+// ResolveMode returns the collection mode. Non-empty flagValue wins; otherwise on a TTY Prompt is used;
+// non-interactive stdin defaults to ModeOneSecondary without prompting.
+func ResolveMode(flagValue string, isTerminal bool, stdin io.Reader, stdout io.Writer) (Mode, error) {
+	if strings.TrimSpace(flagValue) != "" {
+		return ParseMode(flagValue)
+	}
+	if isTerminal {
+		return Prompt(stdin, stdout)
+	}
+	return ModeOneSecondary, nil
+}
+
+func nodeKey(n topologyfinder.ClusterNode) string {
+	return strings.ToLower(strings.TrimSpace(n.Hostname)) + ":" + strconv.Itoa(n.Port)
+}
+
+// shardedTopologyDiscovery is true when getShardMap populated roles or any mongos appears in the node list.
+func shardedTopologyDiscovery(nodes []topologyfinder.ClusterNode) bool {
+	for _, n := range nodes {
+		if strings.TrimSpace(n.ShardMapHostRole) != "" {
+			return true
+		}
+		if strings.EqualFold(n.ReplicaState, "MONGOS") {
+			return true
+		}
+	}
+	return false
+}
+
+func isConfigServerFromShardMap(n topologyfinder.ClusterNode) bool {
+	return strings.EqualFold(strings.TrimSpace(n.ShardMapHostRole), "config")
+}
+
+func sortNodesByHostPort(nodes []topologyfinder.ClusterNode) {
+	sort.Slice(nodes, func(i, j int) bool {
+		if nodes[i].Hostname != nodes[j].Hostname {
+			return nodes[i].Hostname < nodes[j].Hostname
+		}
+		return nodes[i].Port < nodes[j].Port
+	})
+}
+
+// appendShardedInfraOneEach adds at most one mongos and one config-server mongod (getShardMap role "config"),
+// not already in targets, when topology looks sharded. Host/port sort picks which one if several exist.
+func appendShardedInfraOneEach(all []topologyfinder.ClusterNode, targets []topologyfinder.ClusterNode) []topologyfinder.ClusterNode {
+	if !shardedTopologyDiscovery(all) {
+		return targets
+	}
+	seen := make(map[string]bool, len(targets)+len(all))
+	for _, n := range targets {
+		seen[nodeKey(n)] = true
+	}
+	var mongosCandidates, configCandidates []topologyfinder.ClusterNode
+	for _, n := range all {
+		if seen[nodeKey(n)] {
+			continue
+		}
+		if strings.EqualFold(n.ReplicaState, "MONGOS") {
+			mongosCandidates = append(mongosCandidates, n)
+		}
+		if isConfigServerFromShardMap(n) {
+			configCandidates = append(configCandidates, n)
+		}
+	}
+	sortNodesByHostPort(mongosCandidates)
+	sortNodesByHostPort(configCandidates)
+
+	out := append([]topologyfinder.ClusterNode(nil), targets...)
+	if len(mongosCandidates) > 0 {
+		out = append(out, mongosCandidates[0])
+		seen[nodeKey(mongosCandidates[0])] = true
+	}
+	if len(configCandidates) > 0 {
+		k := nodeKey(configCandidates[0])
+		if !seen[k] {
+			out = append(out, configCandidates[0])
+		}
+	}
+	sortNodesByHostPort(out)
+	return out
+}
+
+// Select returns the subset of nodes to collect, or an error if the mode cannot be satisfied.
+func Select(nodes []topologyfinder.ClusterNode, mode Mode) ([]topologyfinder.ClusterNode, error) {
+	switch mode {
+	case ModeAllNodes:
+		out := make([]topologyfinder.ClusterNode, len(nodes))
+		copy(out, nodes)
+		return out, nil
+	case ModeOneSecondary, ModeAllSecondaries:
+		var secondaries []topologyfinder.ClusterNode
+		for _, n := range nodes {
+			if strings.EqualFold(n.ReplicaState, "SECONDARY") {
+				secondaries = append(secondaries, n)
+			}
+		}
+		if len(secondaries) == 0 {
+			return nil, fmt.Errorf("%w; use --collect-nodes=%s to include primaries, or confirm standalone interactively", ErrNoSecondaries, flagAllNodes)
+		}
+		sortNodesByHostPort(secondaries)
+		if mode == ModeOneSecondary {
+			return []topologyfinder.ClusterNode{secondaries[0]}, nil
+		}
+		targets := append([]topologyfinder.ClusterNode(nil), secondaries...)
+		targets = appendShardedInfraOneEach(nodes, targets)
+		return targets, nil
+	default:
+		return nil, fmt.Errorf("unknown collect mode")
+	}
+}

--- a/collectnodes/collectnodes_test.go
+++ b/collectnodes/collectnodes_test.go
@@ -1,0 +1,233 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collectnodes
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"dcrcli/topologyfinder"
+)
+
+func TestModeString(t *testing.T) {
+	if ModeOneSecondary.String() != "one-secondary" || ModeAllNodes.String() != "all-nodes" {
+		t.Fatalf("Mode.String: %s %s", ModeOneSecondary.String(), ModeAllNodes.String())
+	}
+}
+
+func TestParseMode(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want Mode
+		err  bool
+	}{
+		{"one-secondary", ModeOneSecondary, false},
+		{"ONE-SECONDARY", ModeOneSecondary, false},
+		{" all-secondaries ", ModeAllSecondaries, false},
+		{"all-nodes", ModeAllNodes, false},
+		{"", Mode(0), true},
+		{"nope", 0, true},
+	} {
+		m, err := ParseMode(tc.in)
+		if tc.err {
+			if err == nil {
+				t.Fatalf("ParseMode(%q) wanted error", tc.in)
+			}
+			continue
+		}
+		if err != nil || m != tc.want {
+			t.Fatalf("ParseMode(%q) = %v, %v want %v, nil", tc.in, m, err, tc.want)
+		}
+	}
+}
+
+func TestSelectModes(t *testing.T) {
+	nodes := []topologyfinder.ClusterNode{
+		{Hostname: "a", Port: 1, ReplicaState: "PRIMARY"},
+		{Hostname: "b", Port: 2, ReplicaState: "SECONDARY"},
+		{Hostname: "c", Port: 3, ReplicaState: "SECONDARY"},
+		{Hostname: "d", Port: 4, ReplicaState: "ARBITER"},
+	}
+
+	all, err := Select(nodes, ModeAllNodes)
+	if err != nil || len(all) != 4 {
+		t.Fatalf("ModeAllNodes: got %v, %v", all, err)
+	}
+
+	sec, err := Select(nodes, ModeAllSecondaries)
+	if err != nil || len(sec) != 2 {
+		t.Fatalf("ModeAllSecondaries: got %v, %v", sec, err)
+	}
+	if sec[0].Hostname != "b" || sec[1].Hostname != "c" {
+		t.Fatalf("ModeAllSecondaries order: %+v", sec)
+	}
+
+	one, err := Select(nodes, ModeOneSecondary)
+	if err != nil || len(one) != 1 || one[0].Hostname != "b" {
+		t.Fatalf("ModeOneSecondary: got %v, %v", one, err)
+	}
+
+	_, err = Select([]topologyfinder.ClusterNode{
+		{Hostname: "x", Port: 1, ReplicaState: "PRIMARY"},
+	}, ModeOneSecondary)
+	if err == nil || !errors.Is(err, ErrNoSecondaries) {
+		t.Fatalf("expected ErrNoSecondaries wrap: %v", err)
+	}
+}
+
+func TestLooksLikeStandaloneMongod(t *testing.T) {
+	if !LooksLikeStandaloneMongod([]topologyfinder.ClusterNode{{Hostname: "h", Port: 1, ReplicaState: "PRIMARY"}}) {
+		t.Fatal("single primary should look like standalone")
+	}
+	if LooksLikeStandaloneMongod([]topologyfinder.ClusterNode{
+		{ReplicaState: "PRIMARY"}, {ReplicaState: "SECONDARY"},
+	}) {
+		t.Fatal("two nodes is not standalone shape")
+	}
+	if LooksLikeStandaloneMongod([]topologyfinder.ClusterNode{{ReplicaState: "MONGOS"}}) {
+		t.Fatal("mongos alone is not standalone mongod")
+	}
+}
+
+func TestStandalonePrimaryTargets(t *testing.T) {
+	n := []topologyfinder.ClusterNode{{Hostname: "solo", Port: 27017, ReplicaState: "PRIMARY"}}
+	got := StandalonePrimaryTargets(n)
+	if len(got) != 1 || got[0].Hostname != "solo" {
+		t.Fatalf("%+v", got)
+	}
+}
+
+func TestPromptStandaloneCollectPrimary(t *testing.T) {
+	ok, err := PromptStandaloneCollectPrimary(strings.NewReader("y\n"), &bytes.Buffer{})
+	if err != nil || !ok {
+		t.Fatalf("%v %v", ok, err)
+	}
+	ok, err = PromptStandaloneCollectPrimary(strings.NewReader("no\n"), &bytes.Buffer{})
+	if err != nil || ok {
+		t.Fatalf("%v %v", ok, err)
+	}
+}
+
+func TestSelectShardedOneSecondaryOnlyNoInfra(t *testing.T) {
+	nodes := []topologyfinder.ClusterNode{
+		{Hostname: "shardsec", Port: 27018, ReplicaState: "SECONDARY", ShardMapHostRole: "shard0"},
+		{Hostname: "cfg1", Port: 27021, ReplicaState: "PRIMARY", ShardMapHostRole: "config"},
+		{Hostname: "mongos1", Port: 27017, ReplicaState: "MONGOS"},
+	}
+	one, err := Select(nodes, ModeOneSecondary)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(one) != 1 || one[0].Hostname != "shardsec" {
+		t.Fatalf("ModeOneSecondary sharded: want exactly one secondary, got %+v", one)
+	}
+}
+
+func TestSelectShardedAllSecondariesOneMongosOneConfig(t *testing.T) {
+	// Two shard secondaries only (no config SECONDARY here, so "one config" adds cfg1 without duplicating a secondary).
+	nodes := []topologyfinder.ClusterNode{
+		{Hostname: "shardsec", Port: 27018, ReplicaState: "SECONDARY", ShardMapHostRole: "shard0"},
+		{Hostname: "shardsec2", Port: 27118, ReplicaState: "SECONDARY", ShardMapHostRole: "shard1"},
+		{Hostname: "shardpri", Port: 27019, ReplicaState: "PRIMARY", ShardMapHostRole: "shard0"},
+		{Hostname: "cfg1", Port: 27021, ReplicaState: "PRIMARY", ShardMapHostRole: "config"},
+		{Hostname: "cfg2", Port: 27022, ReplicaState: "SECONDARY", ShardMapHostRole: "config"},
+		{Hostname: "mongos1", Port: 27017, ReplicaState: "MONGOS"},
+		{Hostname: "mongos2", Port: 27027, ReplicaState: "MONGOS"},
+	}
+	allSec, err := Select(nodes, ModeAllSecondaries)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// All secondaries = shardsec, shardsec2, cfg2 (3) + one mongos + one config primary not yet listed = cfg1 → 5, or we only add config not in set: cfg2 already in → add cfg1 → 5
+	if len(allSec) != 5 {
+		t.Fatalf("ModeAllSecondaries sharded: want 5 (3 secondaries + 1 mongos + 1 config primary), got %d %v", len(allSec), allSec)
+	}
+	got := map[string]bool{}
+	for _, n := range allSec {
+		got[n.Hostname] = true
+	}
+	if !got["shardsec"] || !got["shardsec2"] || !got["cfg2"] || got["shardpri"] {
+		t.Fatalf("secondaries: %+v", allSec)
+	}
+	mongosCount := 0
+	for _, n := range allSec {
+		if n.ReplicaState == "MONGOS" {
+			mongosCount++
+		}
+	}
+	if mongosCount != 1 || !got["mongos1"] || got["mongos2"] {
+		t.Fatalf("want exactly first sorted mongos: %+v", allSec)
+	}
+	if !got["cfg1"] {
+		t.Fatalf("expected one added config host: %+v", allSec)
+	}
+}
+
+func TestSelectShardedAllSecondariesExtraMongosConfigSkipped(t *testing.T) {
+	nodes := []topologyfinder.ClusterNode{
+		{Hostname: "shardsec", Port: 27018, ReplicaState: "SECONDARY", ShardMapHostRole: "shard0"},
+		{Hostname: "shardsec2", Port: 27118, ReplicaState: "SECONDARY", ShardMapHostRole: "shard1"},
+		{Hostname: "cfg1", Port: 27021, ReplicaState: "PRIMARY", ShardMapHostRole: "config"},
+		{Hostname: "mongos1", Port: 27017, ReplicaState: "MONGOS"},
+		{Hostname: "mongos2", Port: 27027, ReplicaState: "MONGOS"},
+	}
+	allSec, err := Select(nodes, ModeAllSecondaries)
+	if err != nil || len(allSec) != 4 {
+		t.Fatalf("want 4 (2 sec + 1 mongos + 1 cfg), got %d %v", len(allSec), allSec)
+	}
+	got := map[string]bool{}
+	for _, n := range allSec {
+		got[n.Hostname] = true
+	}
+	if !got["mongos1"] || got["mongos2"] || !got["cfg1"] {
+		t.Fatalf("unexpected: %+v", allSec)
+	}
+}
+
+func TestResolveModeFlagPrecedence(t *testing.T) {
+	m, err := ResolveMode("all-nodes", true, strings.NewReader("2\n"), &bytes.Buffer{})
+	if err != nil || m != ModeAllNodes {
+		t.Fatalf("flag should ignore prompt stdin: got %v, %v", m, err)
+	}
+}
+
+func TestResolveModeNonInteractiveDefault(t *testing.T) {
+	m, err := ResolveMode("", false, strings.NewReader(""), &bytes.Buffer{})
+	if err != nil || m != ModeOneSecondary {
+		t.Fatalf("non-TTY default: got %v, %v", m, err)
+	}
+}
+
+func TestPromptChoices(t *testing.T) {
+	for input, want := range map[string]Mode{
+		"\n":         ModeOneSecondary,
+		"1\n":        ModeOneSecondary,
+		"2\n":        ModeAllSecondaries,
+		"3\n":        ModeAllNodes,
+		"  2  \n":    ModeAllSecondaries,
+	} {
+		var buf bytes.Buffer
+		m, err := Prompt(strings.NewReader(input), &buf)
+		if err != nil || m != want {
+			t.Fatalf("Prompt(%q) = %v, %v want %v", input, m, err, want)
+		}
+	}
+	_, err := Prompt(strings.NewReader("9\n"), &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected error for invalid choice")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -16,17 +16,22 @@ package main
 
 import (
 	"bytes"
+	"errors"
+	"flag"
 	"fmt"
 	"log"
 	"log/slog"
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
 	"github.com/briandowns/spinner"
+	"golang.org/x/term"
 
+	"dcrcli/collectnodes"
 	"dcrcli/dcrlogger"
 	"dcrcli/dcroutdir"
 	"dcrcli/fscopy"
@@ -72,6 +77,20 @@ func isMongoNodeAlive(hostname string, port int) (bool, error) {
 
 func main() {
 	var err error
+
+	collectNodesFlag := flag.String(
+		"collect-nodes",
+		"",
+		`Which members to collect from: "one-secondary" (default when non-interactive; one SECONDARY only), "all-secondaries" (every SECONDARY; if sharded, also one mongos and one config server), or "all-nodes" (every discovered host: all mongods, all mongos, all config). If omitted and stdin is a terminal, you are prompted.`,
+	)
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s [options]\n\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Discover MongoDB cluster nodes from a seed and collect diagnostic data (getMongoData, FTDC, logs).\n")
+		fmt.Fprintf(os.Stderr, "By default a single SECONDARY is collected only; use -collect-nodes for all-secondaries (adds one mongos + one config when sharded) or all-nodes.\n\n")
+		fmt.Fprintf(os.Stderr, "Options:\n")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
 
 	dcrcliDebugModeEnv, isEnvSet := os.LookupEnv("DCRCLI_DEBUG_MODE")
 	dcrcliDebugMode := false
@@ -151,7 +170,82 @@ func main() {
 		dcrlog.Warn(fmt.Sprintf("Unable to filter for unique hostnames non-fatal: %s", err.Error()))
 	}
 
-	for _, host := range clustertopology.Allnodes.Nodes {
+	err = clustertopology.ResolveReplicaStates()
+	if err != nil {
+		dcrlog.Warn(fmt.Sprintf("Could not fully resolve replica roles (collection may be limited): %s", err.Error()))
+	}
+
+	// Stop spinner so terminal echo and the collect-nodes prompt are visible (spinner redraw would hide input).
+	s.Stop()
+	fmt.Println()
+
+	isTerm := term.IsTerminal(int(syscall.Stdin))
+	collectMode, err := collectnodes.ResolveMode(*collectNodesFlag, isTerm, os.Stdin, os.Stdout)
+	if err != nil {
+		dcrlog.Error(err.Error())
+		log.Fatal("Invalid collection scope:", err)
+	}
+
+	collectTargets, err := collectnodes.Select(clustertopology.Allnodes.Nodes, collectMode)
+	if err != nil {
+		nodes := clustertopology.Allnodes.Nodes
+		if errors.Is(err, collectnodes.ErrNoSecondaries) &&
+			collectMode != collectnodes.ModeAllNodes &&
+			isTerm &&
+			strings.TrimSpace(*collectNodesFlag) == "" &&
+			collectnodes.LooksLikeStandaloneMongod(nodes) {
+			fmt.Println()
+			fmt.Println("WARNING: A single MongoDB node was discovered and it is not a secondary (typical standalone).")
+			fmt.Println("Options 1 and 2 normally avoid primaries; standalone has no secondary to collect from.")
+			ok, perr := collectnodes.PromptStandaloneCollectPrimary(os.Stdin, os.Stdout)
+			if perr != nil {
+				dcrlog.Error(perr.Error())
+				log.Fatal(perr)
+			}
+			if ok {
+				collectTargets = collectnodes.StandalonePrimaryTargets(nodes)
+				dcrlog.Info("User confirmed collection from standalone primary")
+				fmt.Println("Proceeding: data will be collected from this primary (standalone).")
+				fmt.Println()
+			} else {
+				log.Fatal("Aborted. For standalone use option 3 (all nodes), or pass --collect-nodes=all-nodes, or add a replica set secondary.")
+			}
+		} else {
+			dcrlog.Error(err.Error())
+			if errors.Is(err, collectnodes.ErrNoSecondaries) &&
+				strings.TrimSpace(*collectNodesFlag) != "" &&
+				collectnodes.LooksLikeStandaloneMongod(nodes) {
+				log.Fatal("No secondaries (standalone?). Use --collect-nodes=all-nodes, or run interactively without -collect-nodes to confirm primary collection.")
+			}
+			if errors.Is(err, collectnodes.ErrNoSecondaries) &&
+				!isTerm &&
+				collectnodes.LooksLikeStandaloneMongod(nodes) {
+				log.Fatal("No secondaries (standalone?). Non-interactive run: use --collect-nodes=all-nodes.")
+			}
+			log.Fatal(err)
+		}
+	}
+
+	dcrlog.Info(
+		fmt.Sprintf(
+			"Collect scope: mode=%s, %d target node(s) (from -collect-nodes or interactive prompt)",
+			collectMode.String(),
+			len(collectTargets),
+		),
+	)
+	fmt.Printf(
+		"\nCollecting from %d node(s); scope %s — %s\n",
+		len(collectTargets),
+		collectMode.String(),
+		collectMode.Description(),
+	)
+	for _, t := range collectTargets {
+		dcrlog.Info(fmt.Sprintf("Collection target: %s:%d (%s)", t.Hostname, t.Port, t.ReplicaState))
+	}
+
+	s.Start()
+
+	for _, host := range collectTargets {
 
 		dcrlog.Info(fmt.Sprintf("Collecting logs for MongoDB node - host: %s, port: %d", host.Hostname, host.Port))
 		fmt.Printf("\nCollecting logs for MongoDB node %s:%d\n", host.Hostname, host.Port)

--- a/mongosh/assets/topologyFinder/helloFullCommand.js
+++ b/mongosh/assets/topologyFinder/helloFullCommand.js
@@ -1,0 +1,1 @@
+db.runCommand({ hello: 1 })

--- a/mongosh/assets/topologyFinder/rsStatusMembers.js
+++ b/mongosh/assets/topologyFinder/rsStatusMembers.js
@@ -1,0 +1,10 @@
+(function () {
+  try {
+    var s = rs.status();
+    return s.members.map(function (m) {
+      return { name: m.name, stateStr: m.stateStr };
+    });
+  } catch (e) {
+    return { error: true, message: String(e.message || e) };
+  }
+})()

--- a/mongosh/getShardMap_embed.go
+++ b/mongosh/getShardMap_embed.go
@@ -23,3 +23,9 @@ var GetShardMapScriptCode string
 
 //go:embed assets/topologyFinder/helloCommand.js
 var HelloDBCommand string
+
+//go:embed assets/topologyFinder/rsStatusMembers.js
+var RsStatusMembersCommand string
+
+//go:embed assets/topologyFinder/helloFullCommand.js
+var HelloFullCommand string

--- a/mongosh/mongosh.go
+++ b/mongosh/mongosh.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 func binPath() string {
@@ -44,6 +45,46 @@ func printErrorIfNotNil(err error, msg string) error {
 		return fmt.Errorf("Failed %s : %s\n", msg, err)
 	}
 	return nil
+}
+
+const mongoShellOutputMaxRunes = 2048
+
+// diagnoseMongoShellOutput returns a short hint when mongosh/mongo output matches known failure patterns.
+func diagnoseMongoShellOutput(out string) string {
+	low := strings.ToLower(out)
+	switch {
+	case strings.Contains(low, "econnrefused"), strings.Contains(low, "connection refused"):
+		return "Nothing is accepting connections at that address (mongod/mongos may be stopped, or the port is wrong)."
+	case strings.Contains(low, "enotfound"), strings.Contains(low, "getaddrinfo"):
+		return "The hostname could not be resolved; check spelling and DNS."
+	case strings.Contains(low, "authentication failed"), strings.Contains(low, "bad auth"):
+		return "Authentication failed; check username, password, and auth options in the URI."
+	case strings.Contains(low, "timed out"), strings.Contains(low, "timeout"), strings.Contains(low, "etimedout"):
+		return "The connection timed out; check network paths, firewalls, and that the service is reachable."
+	case strings.Contains(low, "certificate") || (strings.Contains(low, "tls") && strings.Contains(low, "error")):
+		return "TLS/certificate error; if the cluster requires TLS, add the appropriate options to the MongoDB URI."
+	default:
+		return ""
+	}
+}
+
+// formatMongoShellError wraps a failed shell run with captured stdout/stderr (mongosh writes errors there, not only in exit status).
+func formatMongoShellError(operation string, runErr error, out []byte) error {
+	s := strings.TrimSpace(string(out))
+	runes := []rune(s)
+	if len(runes) > mongoShellOutputMaxRunes {
+		s = string(runes[:mongoShellOutputMaxRunes]) + " ... (truncated)"
+	}
+	hint := diagnoseMongoShellOutput(s)
+	var b strings.Builder
+	_, _ = fmt.Fprintf(&b, "Failed %s: %v", operation, runErr)
+	if s != "" {
+		_, _ = fmt.Fprintf(&b, "\nShell output:\n%s", s)
+	}
+	if hint != "" {
+		_, _ = fmt.Fprintf(&b, "\nLikely cause: %s", hint)
+	}
+	return fmt.Errorf("%s", b.String())
 }
 
 type CaptureGetMongoData struct {
@@ -110,11 +151,14 @@ func (cgm *CaptureGetMongoData) execGetMongoDataWithEval() error {
 	cmd.Stdout = cgm.Getparsedjsonoutput
 	cmd.Stderr = cgm.Getparsedjsonoutput
 
-	// fmt.Println("Running the cmdDotRun")
-	return printErrorIfNotNil(
-		cmd.Run(),
-		"in execGetMongoDataWithEval() data collection script execution",
-	)
+	if err := cmd.Run(); err != nil {
+		return formatMongoShellError(
+			"in execGetMongoDataWithEval() data collection script execution",
+			err,
+			cgm.Getparsedjsonoutput.Bytes(),
+		)
+	}
+	return nil
 }
 
 func (cgm *CaptureGetMongoData) execMongoWellnessCheckerWithEval() error {
@@ -147,10 +191,14 @@ func (cgm *CaptureGetMongoData) execMongoWellnessCheckerWithEval() error {
 	cmd.Stdout = cgm.Getparsedjsonoutput
 	cmd.Stderr = cgm.Getparsedjsonoutput
 
-	return printErrorIfNotNil(
-		cmd.Run(),
-		"in execMongoWellnessCheckerWithEval() data collection script execution",
-	)
+	if err := cmd.Run(); err != nil {
+		return formatMongoShellError(
+			"in execMongoWellnessCheckerWithEval() data collection script execution",
+			err,
+			cgm.Getparsedjsonoutput.Bytes(),
+		)
+	}
+	return nil
 }
 
 func (cgm *CaptureGetMongoData) RunMongoShellWithEval() error {
@@ -188,6 +236,32 @@ func (cgm *CaptureGetMongoData) RunMongoShellWithEval() error {
 func (cgm *CaptureGetMongoData) RunHelloDBCommandWithEval() error {
 	cgm.Getparsedjsonoutput = &bytes.Buffer{}
 	cgm.CurrentCommand = &HelloDBCommand
+
+	err := cgm.RunCurrentDBCommand()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RunRsStatusMembersWithEval runs rs.status() on the current Mongo URI and captures member name/stateStr as JSON.
+func (cgm *CaptureGetMongoData) RunRsStatusMembersWithEval() error {
+	cgm.Getparsedjsonoutput = &bytes.Buffer{}
+	cgm.CurrentCommand = &RsStatusMembersCommand
+
+	err := cgm.RunCurrentDBCommand()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RunHelloFullWithEval runs hello against the current Mongo URI and captures the full JSON document.
+func (cgm *CaptureGetMongoData) RunHelloFullWithEval() error {
+	cgm.Getparsedjsonoutput = &bytes.Buffer{}
+	cgm.CurrentCommand = &HelloFullCommand
 
 	err := cgm.RunCurrentDBCommand()
 	if err != nil {
@@ -262,10 +336,14 @@ func (cgm *CaptureGetMongoData) execLegacyMongoShell() error {
 	cmd.Stdout = cgm.Getparsedjsonoutput
 	cmd.Stderr = cgm.Getparsedjsonoutput
 
-	return printErrorIfNotNil(
-		cmd.Run(),
-		*cgm.CurrentCommand,
-	)
+	if err := cmd.Run(); err != nil {
+		return formatMongoShellError(
+			fmt.Sprintf("MongoDB shell (%s)", *cgm.CurrentCommand),
+			err,
+			cgm.Getparsedjsonoutput.Bytes(),
+		)
+	}
+	return nil
 }
 
 func (cgm *CaptureGetMongoData) execMongoSHShell() error {
@@ -299,10 +377,14 @@ func (cgm *CaptureGetMongoData) execMongoSHShell() error {
 	cmd.Stdout = cgm.Getparsedjsonoutput
 	cmd.Stderr = cgm.Getparsedjsonoutput
 
-	return printErrorIfNotNil(
-		cmd.Run(),
-		*cgm.CurrentCommand,
-	)
+	if err := cmd.Run(); err != nil {
+		return formatMongoShellError(
+			fmt.Sprintf("MongoDB shell (%s)", *cgm.CurrentCommand),
+			err,
+			cgm.Getparsedjsonoutput.Bytes(),
+		)
+	}
+	return nil
 }
 
 func (cgm *CaptureGetMongoData) RunGetMongoDLogDetails() error {

--- a/mongosh/mongosh_test.go
+++ b/mongosh/mongosh_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"dcrcli/mongocredentials"
@@ -294,6 +295,18 @@ func TestPrintErrorIfNotNilWithNonNilErrorInput(t *testing.T) {
 }
 
 // ### END TEST printErrorIfNotNil
+
+func TestFormatMongoShellErrorIncludesShellOutputAndHint(t *testing.T) {
+	out := []byte("MongoServerSelectionError: connect ECONNREFUSED 127.0.0.1:27017")
+	err := formatMongoShellError("MongoDB shell (db.runCommand({hello:1}).hosts)", errors.New("exit status 1"), out)
+	msg := err.Error()
+	if !strings.Contains(msg, "Shell output:") || !strings.Contains(msg, "ECONNREFUSED") {
+		t.Fatalf("expected shell output in error: %s", msg)
+	}
+	if !strings.Contains(msg, "Likely cause:") || !strings.Contains(msg, "accepting connections") {
+		t.Fatalf("expected connection hint: %s", msg)
+	}
+}
 
 // ### START TEST runCommandAndCaptureOutputInVariable
 // It calls standard exec.Command

--- a/topologyfinder/noderoles.go
+++ b/topologyfinder/noderoles.go
@@ -1,0 +1,188 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topologyfinder
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type rsMemberRow struct {
+	Name     string `json:"name"`
+	StateStr string `json:"stateStr"`
+}
+
+type rsStatusErr struct {
+	Error   bool   `json:"error"`
+	Message string `json:"message"`
+}
+
+// decodeFirstJSONValue reads one JSON value from b (handles extra trailing noise from the shell).
+func decodeFirstJSONValue(b []byte) (json.RawMessage, error) {
+	dec := json.NewDecoder(bytes.NewReader(bytes.TrimSpace(b)))
+	dec.UseNumber()
+	var raw json.RawMessage
+	if err := dec.Decode(&raw); err != nil {
+		return nil, err
+	}
+	return raw, nil
+}
+
+func parseRsStatusMembersOutput(b []byte) ([]rsMemberRow, bool) {
+	raw, err := decodeFirstJSONValue(b)
+	if err != nil {
+		return nil, false
+	}
+	if len(raw) > 0 && raw[0] == '{' {
+		var errObj rsStatusErr
+		if json.Unmarshal(raw, &errObj) == nil && errObj.Error {
+			return nil, true
+		}
+		return nil, false
+	}
+	var rows []rsMemberRow
+	if json.Unmarshal(raw, &rows) != nil {
+		return nil, false
+	}
+	return rows, false
+}
+
+func memberRowMatchesNode(memberName string, n ClusterNode, tf *TopologyFinder) bool {
+	h, p, err := splitHostPort(memberName, tf.Dcrlog)
+	if err != nil {
+		return false
+	}
+	if p != n.Port {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(h), strings.TrimSpace(n.Hostname))
+}
+
+func replicaStateFromRsRow(stateStr string) string {
+	return strings.ToUpper(strings.TrimSpace(stateStr))
+}
+
+// classifyHelloJSON inspects a hello / hello-like document and returns ReplicaState constants.
+func classifyHelloJSON(b []byte) string {
+	raw, err := decodeFirstJSONValue(b)
+	if err != nil {
+		return "UNKNOWN"
+	}
+	var m map[string]interface{}
+	if json.Unmarshal(raw, &m) != nil {
+		return "UNKNOWN"
+	}
+	if msg, ok := m["msg"].(string); ok && strings.EqualFold(msg, "isdbgrid") {
+		return "MONGOS"
+	}
+	if truthy(m["arbiterOnly"]) {
+		return "ARBITER"
+	}
+	if truthy(m["isWritablePrimary"]) {
+		return "PRIMARY"
+	}
+	if truthy(m["secondary"]) {
+		return "SECONDARY"
+	}
+	return "UNKNOWN"
+}
+
+func truthy(v interface{}) bool {
+	switch t := v.(type) {
+	case bool:
+		return t
+	case json.Number:
+		i, err := t.Int64()
+		return err == nil && i != 0
+	case float64:
+		return t != 0
+	case string:
+		return strings.EqualFold(t, "true") || t == "1"
+	default:
+		return false
+	}
+}
+
+// ResolveReplicaStates fills ReplicaState on each node: rs.status from the seed URI first, then
+// per-node hello for nodes still without a state. Seed Mongo URI is restored before return.
+func (tf *TopologyFinder) ResolveReplicaStates() error {
+	if tf.MongoshCapture.S == nil || tf.Dcrlog == nil {
+		return fmt.Errorf("topologyfinder: MongoshCapture.S and Dcrlog must be set")
+	}
+	s := tf.MongoshCapture.S
+	seedH, seedP := s.Seedmongodhost, s.Seedmongodport
+	defer func() {
+		s.Currentmongodhost = seedH
+		s.Currentmongodport = seedP
+		_ = s.SetMongoURI()
+	}()
+
+	s.Currentmongodhost = seedH
+	s.Currentmongodport = seedP
+	if err := s.SetMongoURI(); err != nil {
+		return err
+	}
+
+	var rows []rsMemberRow
+	if err := tf.MongoshCapture.RunRsStatusMembersWithEval(); err != nil {
+		tf.Dcrlog.Debug(fmt.Sprintf("tftf - rs.status members eval failed, falling back to hello: %v", err))
+	} else {
+		out := tf.MongoshCapture.Getparsedjsonoutput.Bytes()
+		var scriptErr bool
+		rows, scriptErr = parseRsStatusMembersOutput(out)
+		if scriptErr {
+			tf.Dcrlog.Debug("tftf - rs.status script reported error (not a repl set from this connection)")
+			rows = nil
+		}
+	}
+
+	for i := range tf.Allnodes.Nodes {
+		for _, row := range rows {
+			if memberRowMatchesNode(row.Name, tf.Allnodes.Nodes[i], tf) {
+				tf.Allnodes.Nodes[i].ReplicaState = replicaStateFromRsRow(row.StateStr)
+				break
+			}
+		}
+	}
+
+	for i := range tf.Allnodes.Nodes {
+		if tf.Allnodes.Nodes[i].ReplicaState != "" {
+			continue
+		}
+		s.Currentmongodhost = tf.Allnodes.Nodes[i].Hostname
+		s.Currentmongodport = fmt.Sprintf("%d", tf.Allnodes.Nodes[i].Port)
+		if err := s.SetMongoURI(); err != nil {
+			tf.Allnodes.Nodes[i].ReplicaState = "UNKNOWN"
+			continue
+		}
+		if err := tf.MongoshCapture.RunHelloFullWithEval(); err != nil {
+			tf.Dcrlog.Debug(
+				fmt.Sprintf(
+					"tftf - hello for %s:%d failed: %v",
+					tf.Allnodes.Nodes[i].Hostname,
+					tf.Allnodes.Nodes[i].Port,
+					err,
+				),
+			)
+			tf.Allnodes.Nodes[i].ReplicaState = "UNKNOWN"
+			continue
+		}
+		tf.Allnodes.Nodes[i].ReplicaState = classifyHelloJSON(tf.MongoshCapture.Getparsedjsonoutput.Bytes())
+	}
+
+	return nil
+}

--- a/topologyfinder/noderoles_test.go
+++ b/topologyfinder/noderoles_test.go
@@ -1,0 +1,65 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topologyfinder
+
+import (
+	"testing"
+
+	"dcrcli/dcrlogger"
+)
+
+func TestParseRsStatusMembersOutput(t *testing.T) {
+	rows, scriptErr := parseRsStatusMembersOutput([]byte(`[
+	  {"name": "host1:27017", "stateStr": "PRIMARY"},
+	  {"name": "host2:27017", "stateStr": "SECONDARY"}
+	]`))
+	if scriptErr || len(rows) != 2 {
+		t.Fatalf("array: rows=%v scriptErr=%v", rows, scriptErr)
+	}
+	rows, scriptErr = parseRsStatusMembersOutput([]byte(`{"error":true,"message":"no replset"}`))
+	if !scriptErr || rows != nil {
+		t.Fatalf("error object: rows=%v scriptErr=%v", rows, scriptErr)
+	}
+}
+
+func TestClassifyHelloJSON(t *testing.T) {
+	if g := classifyHelloJSON([]byte(`{"secondary": true, "ok": 1}`)); g != "SECONDARY" {
+		t.Fatalf("secondary: %s", g)
+	}
+	if g := classifyHelloJSON([]byte(`{"isWritablePrimary": true}`)); g != "PRIMARY" {
+		t.Fatalf("primary: %s", g)
+	}
+	if g := classifyHelloJSON([]byte(`{"msg": "isdbgrid"}`)); g != "MONGOS" {
+		t.Fatalf("mongos: %s", g)
+	}
+	if g := classifyHelloJSON([]byte(`{"arbiterOnly": true}`)); g != "ARBITER" {
+		t.Fatalf("arbiter: %s", g)
+	}
+}
+
+func TestMemberRowMatchesNode(t *testing.T) {
+	log := dcrlogger.DCRLogger{OutputPrefix: t.TempDir() + "/", FileName: "noderoles_test"}
+	if err := log.Create(); err != nil {
+		t.Fatal(err)
+	}
+	tf := TopologyFinder{Dcrlog: &log}
+	n := ClusterNode{Hostname: "HOST.example", Port: 27017}
+	if !memberRowMatchesNode("host.example:27017", n, &tf) {
+		t.Fatal("expected case-insensitive host match")
+	}
+	if memberRowMatchesNode("host.example:27018", n, &tf) {
+		t.Fatal("port must match")
+	}
+}

--- a/topologyfinder/topologyfinder.go
+++ b/topologyfinder/topologyfinder.go
@@ -30,6 +30,10 @@ import (
 type ClusterNode struct {
 	Hostname string
 	Port     int
+	// ReplicaState is PRIMARY, SECONDARY, ARBITER, MONGOS, or UNKNOWN after ResolveReplicaStates.
+	ReplicaState string
+	// ShardMapHostRole is the getShardMap "hosts" value (e.g. "config", "shard01") when discovered via the sharded path; empty for replica-set-only discovery.
+	ShardMapHostRole string
 }
 
 type ClusterNodes struct {
@@ -140,8 +144,16 @@ func (tf *TopologyFinder) parseShardMapOutput() error {
 
 	tf.Dcrlog.Debug(fmt.Sprintf("tftf - parsing shard output allhosts is: %s", allhosts))
 	// hosts document is of format {'hostname1:port1' : 'shardn/config'... }
-	// ignore the values part only need the keys which are 'hostname1:port1' ...
-	for mongonodestring := range allhosts {
+	for mongonodestring, rawRole := range allhosts {
+		hostRole := ""
+		switch v := rawRole.(type) {
+		case string:
+			hostRole = v
+		default:
+			if rawRole != nil {
+				hostRole = fmt.Sprintf("%v", rawRole)
+			}
+		}
 
 		mongonodeslice := strings.Split(mongonodestring, ":")
 		tf.Dcrlog.Debug(
@@ -177,8 +189,9 @@ func (tf *TopologyFinder) parseShardMapOutput() error {
 		}
 
 		mongonode := ClusterNode{
-			Hostname: hostname,
-			Port:     port,
+			Hostname:         hostname,
+			Port:             port,
+			ShardMapHostRole: hostRole,
 		}
 
 		tf.Dcrlog.Debug(fmt.Sprintf("tftf - appending node %s to allnodes list", mongonodestring))
@@ -268,6 +281,8 @@ func (tf *TopologyFinder) KeepUniqueNodes() error {
 		return err
 	}
 
+	nodesBeforeDedup := append([]ClusterNode(nil), tf.Allnodes.Nodes...)
+
 	allNodesNew := make([]ClusterNode, 0)
 	tf.Allnodes.Nodes = allNodesNew
 
@@ -297,10 +312,11 @@ func (tf *TopologyFinder) KeepUniqueNodes() error {
 			continue
 		}
 
-		// add to the Allnodes
+		// add to the Allnodes (carry over shard map role from any alias for this IP:port group)
 		mongonode := ClusterNode{
-			Hostname: uniqueHostname,
-			Port:     uniqueListenPort,
+			Hostname:         uniqueHostname,
+			Port:             uniqueListenPort,
+			ShardMapHostRole: shardMapRoleFromAliases(nodesBeforeDedup, hostportList, tf.Dcrlog),
 		}
 
 		tf.Dcrlog.Debug(
@@ -312,6 +328,29 @@ func (tf *TopologyFinder) KeepUniqueNodes() error {
 	// replace existing Allnodes
 	tf.Allnodes.Nodes = allNodesNew
 	return nil
+}
+
+// shardMapRoleFromAliases picks a non-empty ShardMapHostRole from nodes matching any host:port alias; prefers "config".
+func shardMapRoleFromAliases(snapshot []ClusterNode, aliases []string, log *dcrlogger.DCRLogger) string {
+	var fallback string
+	for _, alias := range aliases {
+		ah, ap, err := splitHostPort(alias, log)
+		if err != nil {
+			continue
+		}
+		for _, n := range snapshot {
+			if !strings.EqualFold(strings.TrimSpace(n.Hostname), strings.TrimSpace(ah)) || n.Port != ap {
+				continue
+			}
+			if strings.EqualFold(strings.TrimSpace(n.ShardMapHostRole), "config") {
+				return n.ShardMapHostRole
+			}
+			if n.ShardMapHostRole != "" {
+				fallback = n.ShardMapHostRole
+			}
+		}
+	}
+	return fallback
 }
 
 func (tf *TopologyFinder) addSeedNode() error {

--- a/topologyfinder/topologyfinder_test.go
+++ b/topologyfinder/topologyfinder_test.go
@@ -17,11 +17,22 @@ package topologyfinder
 import (
 	"fmt"
 	"testing"
+
+	"dcrcli/dcrlogger"
 )
+
+func testLogger(t *testing.T) *dcrlogger.DCRLogger {
+	t.Helper()
+	log := dcrlogger.DCRLogger{OutputPrefix: t.TempDir() + "/", FileName: "topologyfinder_test"}
+	if err := log.Create(); err != nil {
+		t.Fatal(err)
+	}
+	return &log
+}
 
 // THESE are tests with mongo shell output
 func TestIsParseShardMapWithValidShardMap(t *testing.T) {
-	clustertopology := TopologyFinder{}
+	clustertopology := TopologyFinder{Dcrlog: testLogger(t)}
 
 	// sample getShardMap output from documentation
 	clustertopology.GetShardMapOutput.WriteString(
@@ -71,7 +82,7 @@ func TestIsParseShardMapWithValidShardMap(t *testing.T) {
 }
 
 func TestIsShardMapWithValidString(t *testing.T) {
-	clustertopology := TopologyFinder{}
+	clustertopology := TopologyFinder{Dcrlog: testLogger(t)}
 
 	// sample getShardMap output from documentation
 	clustertopology.GetShardMapOutput.WriteString(
@@ -114,7 +125,7 @@ func TestIsShardMapWithValidString(t *testing.T) {
 }
 
 func TestIsShardMapWithInvalidJSON(t *testing.T) {
-	clustertopology := TopologyFinder{}
+	clustertopology := TopologyFinder{Dcrlog: testLogger(t)}
 
 	// sample getShardMap output from documentation
 	clustertopology.GetShardMapOutput.WriteString(
@@ -132,7 +143,7 @@ func TestIsShardMapWithInvalidJSON(t *testing.T) {
 }
 
 func TestIsShardMapWithReplicaSetOutput(t *testing.T) {
-	clustertopology := TopologyFinder{}
+	clustertopology := TopologyFinder{Dcrlog: testLogger(t)}
 
 	// sample getShardMap output from documentation
 	clustertopology.GetShardMapOutput.WriteString(
@@ -164,7 +175,7 @@ func TestIsShardMapWithReplicaSetOutput(t *testing.T) {
 
 // THESE are tests with mongosh shell output with --json=canonical
 func TestIsParseShardMapWithValidShardMapMongoSHOutput(t *testing.T) {
-	clustertopology := TopologyFinder{}
+	clustertopology := TopologyFinder{Dcrlog: testLogger(t)}
 
 	// sample getShardMap output from documentation
 	clustertopology.GetShardMapOutput.WriteString(
@@ -233,7 +244,7 @@ func TestIsParseShardMapWithValidShardMapMongoSHOutput(t *testing.T) {
 }
 
 func TestIsShardMapWithValidStringMongoSHOutput(t *testing.T) {
-	clustertopology := TopologyFinder{}
+	clustertopology := TopologyFinder{Dcrlog: testLogger(t)}
 	// sample getShardMap output from documentation
 	clustertopology.GetShardMapOutput.WriteString(
 		`{
@@ -294,7 +305,7 @@ func TestIsShardMapWithValidStringMongoSHOutput(t *testing.T) {
 }
 
 func TestIsShardMapWithReplicaSetOutputMongoSHOutput(t *testing.T) {
-	clustertopology := TopologyFinder{}
+	clustertopology := TopologyFinder{Dcrlog: testLogger(t)}
 
 	// sample getShardMap output from documentation
 	clustertopology.GetShardMapOutput.WriteString(


### PR DESCRIPTION
### What changes

Default collection is one secondary so we don’t hit primaries unless the user opts in. Adds -collect-nodes (one-secondary | all-secondaries | all-nodes), an interactive 1/2/3 menu when appropriate, role detection (rs.status + per-node hello), sharded behavior for option 2 (one mongos + one config host), standalone warning + y/N to allow the primary when there’s no secondary, clearer mongosh errors, and FTDC tolerance when metrics.interim vanishes mid-archive. README updated. fscopy / mongocredentials untouched.

**Scopes**

1. One secondary — single secondary only.
2. All secondaries — every secondary; if sharded, + first (by host/port) one mongos and one config mongod not already selected.
3. All nodes — full discovered list.

**How to run it**

- Help: ./dcrcli -h
- Running: Menu only on an interactive terminal and when -collect-nodes is omitted; otherwise use the flag or the non-interactive default (one secondary).
- Standalone: Extra y/N question only in that interactive case; otherwise use all-nodes.
- Typing the menu choice: The spinner is turned off while the menu and questions are shown, so what you type stays visible.

**Security / load (vs old “all nodes”)**

mongosh is still started with a normal argv list (no shell). Before the per-node work (getMongoData, FTDC, logs), we add a few short runs: rs.status() once on the seed when it applies, then hello once per host that still doesn’t have a role after that (typical when the seed is mongos or a host wasn’t in the rs.status map). By default we collect from one secondary, not every discovered host, so primaries often get none of the heavy passes unless you choose all-nodes. When something fails, the error may include more of mongosh’s own text (e.g. host/port, TLS), so shared logs/terminals can show a bit more detail than before.

**Caveats**
Prefer mongosh for sharded/roles; getShardMap may omit some mongos (seed still added); legacy mongo can weaken role detection.


### Quick test checklist

- **Replica set (≥1 secondary)**
  - [ ] Run interactively with no flag, pick **1**, and confirm only one secondary is collected.
  - [ ] Run interactively and pick **2** → all secondaries (+ if sharded: one mongos + one config).
  - [ ] Run interactively and pick **3** → every discovered host.


- **-collect-nodes flag**
  - [ ] `dcrcli -collect-nodes=one-secondary` → no menu; one secondary only.
  - [ ] `dcrcli -collect-nodes=all-secondaries` → matches scope; no prompts.
  - [ ] `dcrcli -collect-nodes=all-nodes` → matches scope; no prompts.


- **Standalone (single mongod)**
  - [ ] Interactive, options **1** or **2** → warning + `y/N`; `y` collects that host; `n` exits cleanly.
  - [ ] Same scenario with `-collect-nodes=one-secondary` → no `y/N`; must use `all-nodes` or expect a clear error.


-  **Sharded (mongos seed)**
   - [ ] Option **2**: targets include all secondaries + one mongos + one config (not every router).
   - [ ] Option **3**: all listed hosts.


- **Failure readability**
   - [ ] Stop mongod / wrong port → error shows mongosh output + sensible hint (e.g. connection refused).


- **FTDC / logs**
   - [ ] Local node with live `diagnostic.data` → archive completes; no fatal if `metrics.interim` races (at most a warning).


- **UX**
   - [ ] During 1/2/3 menu, spinner off → typed choice visible; confirmation line after choice.


- **Help**
   - [ ] `dcrcli -h` mentions `-collect-nodes` and behavior.