### PR TITLE
MIGRATION-841

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ test.out
 outputs/
 *.log
 .DS_Store
-
+.claude/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This enables centralized diagnostics and faster troubleshooting across replica s
 - [Releases](#releases)
 - [Prerequisites](#prerequisites)
 - [Usage](#usage)
+  - [Config File (recommended)](#config-file-recommended)
   - [Collection scope (which nodes)](#collection-scope-which-nodes)
 - [Output Location](#output-location)
 - [Internal Notes](#internal-notes)
@@ -78,12 +79,81 @@ Follow these steps:
 chmod +x <binary-name>
 ```
 
-4. Run:
+4. Run using a config file (recommended) or interactively:
+
+**With a config file** — no prompts, easy to re-run and fix:
+```
+./<binary-name> -config dcrcli.config.json
+```
+
+**Interactively** — follow on-screen prompts for credentials, SSH user, and which nodes to collect:
 ```
 ./<binary-name>
 ```
 
-5. Follow the on-screen prompts to start data collection (credentials, SSH user, then—after topology is found—which nodes to collect).
+Run `./<binary-name> -h` for a full summary of flags.
+
+### Config File (recommended)
+
+A config file lets you set all connection details upfront so you never have to re-enter them. If a run fails, the error message tells you exactly which field to fix — just update the file and re-run.
+
+**Step 1 — Generate a sample file:**
+```
+./<binary-name> -generate-config dcrcli.config.json
+```
+
+This writes a `dcrcli.config.json` file with placeholder values and prints a description of each field. The file is created with `0600` permissions to keep the password field private.
+
+**Step 2 — Edit the file with your values:**
+```json
+{
+  "cluster_name":  "my-cluster",
+  "seed_host":     "localhost",
+  "seed_port":     "27017",
+  "username":      "",
+  "password":      "",
+  "uri_options":   "",
+  "ssh_username":  "",
+  "collect_nodes": "one-secondary"
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `cluster_name` | Display name used for the output directory. |
+| `seed_host` | Hostname or IP of a seed mongod or mongos. Defaults to `localhost` if blank. |
+| `seed_port` | Port of the seed node. Defaults to `27017` if blank. |
+| `username` | MongoDB admin username. Leave blank for clusters without authentication. |
+| `password` | MongoDB admin password. Leave blank for clusters without authentication. |
+| `uri_options` | Extra URI connection options in `name=value&name2=value2` format. **Do not include `replicaSet` here** — dcrcli discovers topology itself. |
+| `ssh_username` | OS username for passwordless SSH to remote cluster nodes. Leave blank if all nodes are on the same machine as dcrcli. |
+| `collect_nodes` | Which nodes to collect from: `one-secondary` (default), `all-secondaries`, or `all-nodes`. Leave blank to be prompted interactively. |
+
+**Step 3 — Run:**
+```
+./<binary-name> -config dcrcli.config.json
+```
+
+dcrcli prints a summary of what was loaded from the file before proceeding, so you can confirm the values at a glance:
+```
+Loading config from: dcrcli.config.json
+  cluster_name:  my-cluster
+  seed_host:     mongo-node1.internal
+  seed_port:     27017
+  username:      diag_user
+  password:      [set]
+  uri_options:   (none)
+  ssh_username:  ubuntu
+  collect_nodes: one-secondary
+```
+
+If a field fails validation, the error names the field and tells you which file to edit:
+```
+Config validation failed: config field "uri_options": FATAL: do not enter replicaSet in options
+Fix the value in dcrcli.config.json and re-run.
+```
+
+> **Note:** The `-collect-nodes` flag always takes precedence over the `collect_nodes` config file value, which in turn takes precedence over the interactive prompt.
 
 ### Collection scope (which nodes)
 After topology is discovered, dcrcli asks **which nodes to collect from** (unless you pass a flag). You can also pass:
@@ -110,16 +180,6 @@ Run `./<binary-name> -h` for a short summary of flags.
 **Replica sets (non-sharded):** **all-secondaries** and **one-secondary** only collect secondary `mongod` members; there is no separate mongos/config layer.
 
 **Standalone (single `mongod`):** If only **one** data node is discovered and it is **not** a secondary (normal for standalone), and you use options **1** or **2** without **`-collect-nodes`**, dcrcli prints a **WARNING** and asks whether to collect from that **primary** anyway (**y** / **yes** to continue). There is no extra prompt when you pass **`-collect-nodes`** or when stdin is not a terminal—use **`-collect-nodes=all-nodes`** for unattended standalone runs.
-
-Terminologies:
-
-- **Cluster Name:** Give the name of cluster to recognise easily ( APAC_PROD_RS)
-- **Hostname of Seed Mongod/Mongos:** Recommended to give mongos hostname for sharded cluster, Primary hostname for replica set.
-- **Port number of Seed Mongod/Mongos instance:** Port number at which mongos/mongod running on the host which we have given in previous ask.
-- **Admin Username:** Admin username of database instance.
-- **Admin Password:** Admin user password of database instance.
-- **MongoURI options:** Any special connection string option to be specified. 
-- **SSH User:** Mention the username that have SSH access to the clusters machines. Ensure that this user has read-write permissions on the dbpath of each machine.
 
 ## Output Location
 - Collected artifacts are written under ./outputs.

--- a/dcrconfig/dcrconfig.go
+++ b/dcrconfig/dcrconfig.go
@@ -1,0 +1,90 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dcrconfig
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// Config holds all connection and collection settings that dcrcli needs.
+// Generate a sample with: ./dcrcli -generate-config dcrcli.config.json
+type Config struct {
+	// ClusterName is the display name used for the output directory.
+	ClusterName string `json:"cluster_name"`
+
+	// SeedHost is the hostname or IP of a seed mongod or mongos node.
+	SeedHost string `json:"seed_host"`
+
+	// SeedPort is the port of the seed node. Defaults to "27017" if empty.
+	SeedPort string `json:"seed_port"`
+
+	// Username is the MongoDB admin username.
+	// Leave empty for clusters running without authentication.
+	Username string `json:"username"`
+
+	// Password is the MongoDB admin password.
+	// Leave empty for clusters running without authentication.
+	Password string `json:"password"`
+
+	// URIOptions are extra MongoDB URI connection options in name=value&name2=value2 format.
+	// Do NOT include replicaSet here — dcrcli discovers topology itself.
+	URIOptions string `json:"uri_options"`
+
+	// SSHUsername is the OS user for passwordless SSH to remote cluster nodes.
+	// Leave empty if all cluster nodes are on the same machine as dcrcli.
+	SSHUsername string `json:"ssh_username"`
+
+	// CollectNodes controls which nodes to collect diagnostic data from.
+	// Valid values: "one-secondary" (default), "all-secondaries", "all-nodes".
+	// Leave empty to be prompted interactively when running in a terminal.
+	CollectNodes string `json:"collect_nodes"`
+}
+
+// Load reads and parses a JSON config file at the given path.
+// On any parse or validation error it returns a message that includes the
+// field name so the user knows exactly what to fix in the file.
+func Load(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read config file %q: %w", path, err)
+	}
+	var c Config
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("invalid JSON in config file %q: %w", path, err)
+	}
+	return &c, nil
+}
+
+// GenerateSample writes a sample config file with placeholder values to path.
+// The file is created with 0600 permissions so the password field stays private.
+func GenerateSample(path string) error {
+	sample := Config{
+		ClusterName:  "my-cluster",
+		SeedHost:     "localhost",
+		SeedPort:     "27017",
+		Username:     "",
+		Password:     "",
+		URIOptions:   "",
+		SSHUsername:  "",
+		CollectNodes: "one-secondary",
+	}
+	data, err := json.MarshalIndent(sample, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0600)
+}

--- a/fscopy/fscopy.go
+++ b/fscopy/fscopy.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"dcrcli/dcrconfig"
 	"dcrcli/dcrlogger"
 )
 
@@ -55,6 +56,18 @@ func (rc *RemoteCred) Get() error {
 	}
 
 	return nil
+}
+
+// GetFromConfig populates the SSH username from a config file instead of an interactive prompt.
+func (rc *RemoteCred) GetFromConfig(c *dcrconfig.Config) {
+	rc.Username = strings.TrimSpace(c.SSHUsername)
+	if rc.Username == "" {
+		rc.Available = false
+		rc.Dcrlog.Debug("config ssh_username empty, assuming all nodes local")
+	} else {
+		rc.Available = true
+		rc.Dcrlog.Debug(fmt.Sprintf("config ssh_username: %s", rc.Username))
+	}
 }
 
 type SourceDir struct {

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ import (
 	"golang.org/x/term"
 
 	"dcrcli/collectnodes"
+	"dcrcli/dcrconfig"
 	"dcrcli/dcrlogger"
 	"dcrcli/dcroutdir"
 	"dcrcli/fscopy"
@@ -83,6 +84,16 @@ func main() {
 		"",
 		`Which members to collect from: "one-secondary" (default when non-interactive; one SECONDARY only), "all-secondaries" (every SECONDARY; if sharded, also one mongos and one config server), or "all-nodes" (every discovered host: all mongods, all mongos, all config). If omitted and stdin is a terminal, you are prompted.`,
 	)
+	configFile := flag.String(
+		"config",
+		"",
+		"Path to a JSON config file with connection details. Use -generate-config to create a sample.",
+	)
+	generateConfig := flag.String(
+		"generate-config",
+		"",
+		"Write a sample config file to the given path and exit. Example: ./dcrcli -generate-config dcrcli.config.json",
+	)
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "Usage: %s [options]\n\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "Discover MongoDB cluster nodes from a seed and collect diagnostic data (getMongoData, FTDC, logs).\n")
@@ -91,6 +102,24 @@ func main() {
 		flag.PrintDefaults()
 	}
 	flag.Parse()
+
+	if *generateConfig != "" {
+		if err := dcrconfig.GenerateSample(*generateConfig); err != nil {
+			log.Fatal("Failed to write sample config file:", err)
+		}
+		fmt.Println("Sample config written to:", *generateConfig)
+		fmt.Println()
+		fmt.Println("Fields:")
+		fmt.Println("  cluster_name   — display name for the output directory")
+		fmt.Println("  seed_host      — hostname or IP of a seed mongod/mongos")
+		fmt.Println("  seed_port      — port of the seed node (default 27017)")
+		fmt.Println("  username       — MongoDB admin username (blank = no auth)")
+		fmt.Println("  password       — MongoDB admin password (blank = no auth)")
+		fmt.Println("  uri_options    — extra URI options e.g. tls=true (no replicaSet)")
+		fmt.Println("  ssh_username   — OS user for passwordless SSH to remote nodes (blank = all local)")
+		fmt.Println("  collect_nodes  — one-secondary | all-secondaries | all-nodes (blank = prompt)")
+		os.Exit(0)
+	}
 
 	dcrcliDebugModeEnv, isEnvSet := os.LookupEnv("DCRCLI_DEBUG_MODE")
 	dcrcliDebugMode := false
@@ -116,15 +145,72 @@ func main() {
 	cred := mongocredentials.Mongocredentials{}
 	cred.Dcrlog = &dcrlog
 
-	err = cred.Get()
-	if err != nil {
-		dcrlog.Error(err.Error())
-		log.Fatal("Error why getting DB credentials aborting!")
-	}
-
 	remoteCred := fscopy.RemoteCred{}
 	remoteCred.Dcrlog = &dcrlog
-	remoteCred.Get()
+
+	// collectModeStr merges the -collect-nodes flag with any value from the config file.
+	// A CLI flag always wins; config value is used when no flag is given.
+	collectModeStr := *collectNodesFlag
+
+	if *configFile != "" {
+		cfg, err := dcrconfig.Load(*configFile)
+		if err != nil {
+			dcrlog.Error(err.Error())
+			log.Fatal("Failed to load config file:", err)
+		}
+
+		fmt.Println("Loading config from:", *configFile)
+		fmt.Printf("  cluster_name:  %s\n", cfg.ClusterName)
+		fmt.Printf("  seed_host:     %s\n", cfg.SeedHost)
+		fmt.Printf("  seed_port:     %s\n", cfg.SeedPort)
+		if cfg.Username != "" {
+			fmt.Printf("  username:      %s\n", cfg.Username)
+		} else {
+			fmt.Println("  username:      (none — no-auth cluster)")
+		}
+		if cfg.Password != "" {
+			fmt.Println("  password:      [set]")
+		} else {
+			fmt.Println("  password:      (none)")
+		}
+		if cfg.URIOptions != "" {
+			fmt.Printf("  uri_options:   %s\n", cfg.URIOptions)
+		} else {
+			fmt.Println("  uri_options:   (none)")
+		}
+		if cfg.SSHUsername != "" {
+			fmt.Printf("  ssh_username:  %s\n", cfg.SSHUsername)
+		} else {
+			fmt.Println("  ssh_username:  (none — all nodes treated as local)")
+		}
+		if cfg.CollectNodes != "" {
+			fmt.Printf("  collect_nodes: %s\n", cfg.CollectNodes)
+		} else {
+			fmt.Println("  collect_nodes: (will prompt interactively)")
+		}
+		fmt.Println()
+
+		if err := cred.GetFromConfig(cfg); err != nil {
+			dcrlog.Error(err.Error())
+			fmt.Println()
+			fmt.Println("Config validation failed:", err)
+			fmt.Println("Fix the value in", *configFile, "and re-run.")
+			os.Exit(1)
+		}
+
+		remoteCred.GetFromConfig(cfg)
+
+		if collectModeStr == "" {
+			collectModeStr = cfg.CollectNodes
+		}
+	} else {
+		err = cred.Get()
+		if err != nil {
+			dcrlog.Error(err.Error())
+			log.Fatal("Error while getting DB credentials aborting!")
+		}
+		remoteCred.Get()
+	}
 
 	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
 	s.Start()
@@ -180,7 +266,7 @@ func main() {
 	fmt.Println()
 
 	isTerm := term.IsTerminal(int(syscall.Stdin))
-	collectMode, err := collectnodes.ResolveMode(*collectNodesFlag, isTerm, os.Stdin, os.Stdout)
+	collectMode, err := collectnodes.ResolveMode(collectModeStr, isTerm, os.Stdin, os.Stdout)
 	if err != nil {
 		dcrlog.Error(err.Error())
 		log.Fatal("Invalid collection scope:", err)
@@ -192,7 +278,7 @@ func main() {
 		if errors.Is(err, collectnodes.ErrNoSecondaries) &&
 			collectMode != collectnodes.ModeAllNodes &&
 			isTerm &&
-			strings.TrimSpace(*collectNodesFlag) == "" &&
+			strings.TrimSpace(collectModeStr) == "" &&
 			collectnodes.LooksLikeStandaloneMongod(nodes) {
 			fmt.Println()
 			fmt.Println("WARNING: A single MongoDB node was discovered and it is not a secondary (typical standalone).")
@@ -213,7 +299,7 @@ func main() {
 		} else {
 			dcrlog.Error(err.Error())
 			if errors.Is(err, collectnodes.ErrNoSecondaries) &&
-				strings.TrimSpace(*collectNodesFlag) != "" &&
+				strings.TrimSpace(collectModeStr) != "" &&
 				collectnodes.LooksLikeStandaloneMongod(nodes) {
 				log.Fatal("No secondaries (standalone?). Use --collect-nodes=all-nodes, or run interactively without -collect-nodes to confirm primary collection.")
 			}

--- a/mongocredentials/mongocredentials.go
+++ b/mongocredentials/mongocredentials.go
@@ -28,6 +28,7 @@ import (
 
 	"golang.org/x/term"
 
+	"dcrcli/dcrconfig"
 	"dcrcli/dcrlogger"
 )
 
@@ -303,4 +304,55 @@ func (s *Mongocredentials) Get() error {
 	s.SetMongoURI()
 
 	return nil
+}
+
+// GetFromConfig populates credentials from a config file instead of interactive prompts.
+// Any validation error names the offending config field so the user knows what to fix.
+func (s *Mongocredentials) GetFromConfig(c *dcrconfig.Config) error {
+	s.Clustername = strings.TrimSpace(c.ClusterName)
+	if s.Clustername == "" {
+		s.generateUniqueName()
+	}
+	if err := checkStringLessThan16MB(s.Clustername); err != nil {
+		return fmt.Errorf("config field \"cluster_name\": %w", err)
+	}
+
+	s.Seedmongodhost = strings.TrimSpace(c.SeedHost)
+	if s.Seedmongodhost == "" {
+		s.Seedmongodhost = "localhost"
+		s.Dcrlog.Debug("config seed_host empty, defaulting to localhost")
+	}
+	if err := checkStringLessThan16MB(s.Seedmongodhost); err != nil {
+		return fmt.Errorf("config field \"seed_host\": %w", err)
+	}
+
+	s.Seedmongodport = strings.TrimSpace(c.SeedPort)
+	if s.Seedmongodport == "" {
+		s.Seedmongodport = "27017"
+		s.Dcrlog.Debug("config seed_port empty, defaulting to 27017")
+	}
+	if err := checkValidListenerPort(s.Seedmongodport); err != nil {
+		return fmt.Errorf("config field \"seed_port\": %w", err)
+	}
+
+	s.Username = strings.TrimSpace(c.Username)
+	if err := checkStringLessThan16MB(s.Username); err != nil {
+		return fmt.Errorf("config field \"username\": %w", err)
+	}
+
+	s.Password = c.Password
+	if err := checkStringLessThan16MB(s.Password); err != nil {
+		return fmt.Errorf("config field \"password\": %w", err)
+	}
+
+	s.Mongourioptions = strings.TrimSpace(c.URIOptions)
+	if s.Mongourioptions != "" {
+		if err := s.validationOfMongoConnectionURIoptions(); err != nil {
+			return fmt.Errorf("config field \"uri_options\": %w", err)
+		}
+	}
+
+	s.Currentmongodhost = s.Seedmongodhost
+	s.Currentmongodport = s.Seedmongodport
+	return s.SetMongoURI()
 }


### PR DESCRIPTION
Added --config <file> feature. 

A config file lets you set all connection details upfront so you never have to re-enter them. If a run fails, the error message tells you exactly which field to fix — just update the file and re-run.