### PR TITLE
Collect data from nodes one by one after checking the health of all n…

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This enables centralized diagnostics and faster troubleshooting across replica s
 - [Usage](#usage)
   - [Config File (recommended)](#config-file-recommended)
   - [Collection scope (which nodes)](#collection-scope-which-nodes)
+  - [Cluster health pre-check](#cluster-health-pre-check)
 - [Output Location](#output-location)
 - [Internal Notes](#internal-notes)
 - [Build from Source](#build-from-source)
@@ -39,6 +40,7 @@ For a successful collection, ensure the following before running dcrcli:
 - Hostnames of all nodes in the MongoDB cluster must be resolvable from the machine running dcrcli.
 - Use the same hostnames as the cluster configuration (e.g., those shown by rs.status()).
 - Allow firewall access from the dcrcli host to MongoDB ports (e.g., 27017, 27018, etc.).
+- **Every** discovered node (all `mongod`s, plus `mongos` and config-server members on sharded topologies) must be reachable from the dcrcli host on its listening port for the **whole duration** of the run. dcrcli probes every member before starting and again before each per-node collection step, and **aborts with exit code 1** if any node is unreachable (see [Cluster health pre-check](#cluster-health-pre-check)).
 - When FTDC and MongoDB logs are also needed:
   - Allow SSH access from the dcrcli host to all nodes in the cluster.
 
@@ -202,6 +204,35 @@ Run `./<binary-name> -h` for a short summary of flags.
 **Replica sets (non-sharded):** **all-secondaries** and **one-secondary** only collect secondary `mongod` members; there is no separate mongos/config layer.
 
 **Standalone (single `mongod`):** If only **one** data node is discovered and it is **not** a secondary (normal for standalone), and you use options **1** or **2** without **`-collect-nodes`**, dcrcli prints a **WARNING** and asks whether to collect from that **primary** anyway (**y** / **yes** to continue). There is no extra prompt when you pass **`-collect-nodes`** or when stdin is not a terminal—use **`-collect-nodes=all-nodes`** for unattended standalone runs.
+
+### Cluster health pre-check
+dcrcli runs `getMongoData` against live (typically production) clusters, so it refuses to collect data from any node while another cluster member is unreachable. Proceeding in that state can mask a partial outage and adds avoidable load to a cluster that is already degraded.
+
+The health check is a lightweight TCP probe (5-second timeout per node, sequential) against **every** node discovered by the topology finder — not just the nodes selected by `-collect-nodes`. On a sharded topology this includes all `mongod`s plus the `mongos` and config-server members that were discovered.
+
+It runs in two phases:
+
+| Phase | When | What happens on failure |
+|-------|------|-------------------------|
+| **pre-collection** | Once, right after topology discovery and before the first node is touched | dcrcli aborts before any `getMongoData`, FTDC, or log copy work runs |
+| **pre-iteration** | At the start of every per-target iteration of the collection loop | dcrcli aborts before moving on to the next target, so a mid-run degradation does not stack additional load on the cluster |
+
+When a node is unreachable, dcrcli prints an `ERROR` banner listing every offending `host:port`, records a terminating message in the dcrcli log (`dcrlogfile_*.log`), and exits with **code 1**. Example console output:
+
+```
+######################################################################
+#                                 ERROR                              #
+######################################################################
+
+Cluster health check failed (pre-iteration).
+The following MongoDB node(s) are unreachable:
+  - shard0-rs1.example.net:27017
+
+dcrcli runs getMongoData against live clusters; refusing to proceed while any cluster node is down to avoid added production risk.
+Verify all members are healthy (e.g. rs.status()) and retry.
+```
+
+If you see this, verify the named member with `rs.status()` (or `sh.status()` on a sharded cluster), bring it back, and retry. There is no flag to bypass the check — it is intentional.
 
 ## Output Location
 - Collected artifacts are written under ./outputs.

--- a/main.go
+++ b/main.go
@@ -76,6 +76,109 @@ func isMongoNodeAlive(hostname string, port int) (bool, error) {
 	return true, nil
 }
 
+// checkAllNodesAlive probes every supplied cluster node with isMongoNodeAlive and
+// returns the subset of nodes that did not respond, along with the last connection
+// error observed. Probes are sequential to match the conservative, low-footprint
+// network behaviour of the rest of dcrcli.
+// Each probe result is logged: Debug for reachable nodes, Error for unreachable.
+// Parameters:
+// - nodes: All cluster nodes discovered by the topology finder.
+// - dcrlog: Logger used to record per-node probe results.
+// Returns:
+// - []topologyfinder.ClusterNode: Nodes that failed the TCP probe.
+// - error: The last connection error observed while probing; informational only and may be nil even when unreachable nodes are present.
+func checkAllNodesAlive(
+	nodes []topologyfinder.ClusterNode,
+	dcrlog *dcrlogger.DCRLogger,
+) ([]topologyfinder.ClusterNode, error) {
+	unhealthy := make([]topologyfinder.ClusterNode, 0)
+	var lastErr error
+
+	for _, n := range nodes {
+		alive, err := isMongoNodeAlive(n.Hostname, n.Port)
+		if !alive {
+			if err != nil {
+				lastErr = err
+				dcrlog.Error(
+					fmt.Sprintf(
+						"Health check: MongoDB node %s:%d is unreachable: %v",
+						n.Hostname, n.Port, err,
+					),
+				)
+			} else {
+				dcrlog.Error(
+					fmt.Sprintf(
+						"Health check: MongoDB node %s:%d is unreachable",
+						n.Hostname, n.Port,
+					),
+				)
+			}
+			unhealthy = append(unhealthy, n)
+			continue
+		}
+		dcrlog.Debug(
+			fmt.Sprintf("Health check: MongoDB node %s:%d is reachable", n.Hostname, n.Port),
+		)
+	}
+
+	return unhealthy, lastErr
+}
+
+// abortIfAnyNodeUnhealthy probes every cluster node and terminates the run when any
+// node is unreachable. dcrcli collects diagnostic data via getMongoData against live
+// (typically production) clusters; proceeding while a member is already down risks
+// further degrading availability. The gate is invoked once before the per-target
+// collection loop starts and again at the top of every iteration so that
+// degradations occurring mid-run also stop the tool.
+// Parameters:
+// - nodes: All cluster nodes discovered by the topology finder.
+// - phase: Short label included in log/console messages (e.g. "pre-collection", "pre-iteration") used to disambiguate where the gate fired.
+// - dcrlog: Logger used to emit health-check progress and failure details.
+func abortIfAnyNodeUnhealthy(
+	nodes []topologyfinder.ClusterNode,
+	phase string,
+	dcrlog *dcrlogger.DCRLogger,
+) {
+	dcrlog.Info(
+		fmt.Sprintf("Health check (%s): probing %d cluster node(s)", phase, len(nodes)),
+	)
+
+	unhealthy, lastErr := checkAllNodesAlive(nodes, dcrlog)
+	if len(unhealthy) == 0 {
+		dcrlog.Info(
+			fmt.Sprintf("Health check (%s): all %d node(s) reachable", phase, len(nodes)),
+		)
+		return
+	}
+
+	fmt.Printf("\n")
+	fmt.Println("######################################################################")
+	fmt.Println("#                                 ERROR                              #")
+	fmt.Println("######################################################################")
+	fmt.Printf("\nCluster health check failed (%s).\n", phase)
+	fmt.Println("The following MongoDB node(s) are unreachable:")
+	for _, u := range unhealthy {
+		fmt.Printf("  - %s:%d\n", u.Hostname, u.Port)
+	}
+	fmt.Println()
+	fmt.Println(
+		"dcrcli runs getMongoData against live clusters; refusing to proceed while any cluster node is down to avoid added production risk.",
+	)
+	fmt.Println("Verify all members are healthy (e.g. rs.status()) and retry.")
+	if lastErr != nil {
+		fmt.Printf("Last connection error: %v\n", lastErr)
+	}
+	fmt.Println()
+
+	dcrlog.Error(
+		fmt.Sprintf(
+			"Terminating DCR-CLI execution: %d cluster node(s) unhealthy during %s health check",
+			len(unhealthy), phase,
+		),
+	)
+	os.Exit(1)
+}
+
 func main() {
 	var err error
 
@@ -337,9 +440,20 @@ func main() {
 		dcrlog.Info(fmt.Sprintf("Collection target: %s:%d (%s)", t.Hostname, t.Port, t.ReplicaState))
 	}
 
+	// Pre-collection cluster-wide health gate: refuse to start data collection if any
+	// member of the discovered topology is already unreachable. getMongoData is run
+	// against live (typically production) clusters, so taking on additional risk while
+	// a node is down is unacceptable.
+	abortIfAnyNodeUnhealthy(clustertopology.Allnodes.Nodes, "pre-collection", &dcrlog)
+
 	s.Start()
 
 	for _, host := range collectTargets {
+
+		// Per-iteration cluster-wide health gate: re-probe every node before moving on
+		// to the next collection target so we never stack additional load on a cluster
+		// that has degraded mid-run.
+		abortIfAnyNodeUnhealthy(clustertopology.Allnodes.Nodes, "pre-iteration", &dcrlog)
 
 		dcrlog.Info(fmt.Sprintf("Collecting logs for MongoDB node - host: %s, port: %d", host.Hostname, host.Port))
 		fmt.Printf("\nCollecting logs for MongoDB node %s:%d\n", host.Hostname, host.Port)


### PR DESCRIPTION
## Summary
Adds a cluster-wide health check that blocks `getMongoData` collection when any cluster node is unreachable. dcrcli typically runs against production; if a member is already down, collecting from the rest can mask a partial outage and add avoidable load to a degraded cluster.
## Behavior
- Before collection starts, dcrcli probes **every** discovered node (all `mongod`s, plus `mongos` and config-server members on sharded topologies).
- The same probe runs again at the start of each per-target iteration, so mid-run degradations also stop the tool.
- If any node is unreachable, dcrcli prints an `ERROR` banner listing the offending `host:port`(s), logs the termination cause, and exits with code 1.
- Probe is a 5-second TCP `DialTimeout` per node, run sequentially — reuses the existing `isMongoNodeAlive` (no new probe path, no new deps).
## Files
- `main.go` — `+114` lines: adds `checkAllNodesAlive`, `abortIfAnyNodeUnhealthy`, and two call-sites (pre-collection, pre-iteration).
- `README.md` — `+31` lines: TOC entry, a Prerequisites bullet, and a new "Cluster health pre-check" sub-section with a sample banner.
## Test plan
- [ ] Healthy replica set, `-collect-nodes=one-secondary` → completes normally.
- [ ] Stop the primary, run dcrcli targeting a secondary → aborts before any `getMongoData`, banner names the primary.
- [ ] Healthy sharded cluster (mongos seed), `-collect-nodes=all-secondaries` → mongos + config server probed, run proceeds.
- [ ] Kill a node between iterations → next pre-iteration gate aborts.