### PR TITLE
MIGRATION-968 - Suppress archive warnings

### DIFF
--- a/archiver/archiver.go
+++ b/archiver/archiver.go
@@ -44,7 +44,6 @@ func TarWithPatternMatch(src string, filepattern string, writers ...io.Writer) e
 		if err != nil {
 			// diagnostic.data/metrics.interim is recreated/removed by mongod while we walk; treat as non-fatal.
 			if errors.Is(err, fs.ErrNotExist) {
-				fmt.Println("WARNING: In archiving process skipping path removed during walk (e.g. metrics.interim):", err)
 				return nil
 			}
 			fmt.Println("ERROR: In archiving process", err)
@@ -87,16 +86,18 @@ func TarWithPatternMatch(src string, filepattern string, writers ...io.Writer) e
 		f, err := os.Open(file)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
-				fmt.Println("WARNING: In archiving process file disappeared before copy:", file)
 				return nil
 			}
 			fmt.Println("ERROR: In archiving process os.Open: ", err)
 			return err
 		}
 
-		if _, err := io.Copy(tw, f); err != nil {
-			fmt.Println("WARNING: In archiving process of file", fi.Name(), " io.Copy: ", err)
-			return nil
+		if _, err := io.Copy(tw, io.LimitReader(f, fi.Size())); err != nil {
+			if errors.Is(err, tar.ErrWriteTooLong) {
+				return nil
+			}
+			fmt.Println("ERROR: In archiving process of file", fi.Name(), " io.Copy: ", err)
+			return err
 		}
 
 		f.Close()

--- a/archiver/archiver_test.go
+++ b/archiver/archiver_test.go
@@ -15,6 +15,9 @@
 package archiver
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -25,5 +28,39 @@ func TestTarWithPatternMatchWithNonExistentSource(t *testing.T) {
 	err := TarWithPatternMatch(got, "metrics.*")
 	if err == nil {
 		t.Fatalf("Should error out on non-existent source folder")
+	}
+}
+
+// Test TarWithPatternMatch - for handling a file that grows during archiving
+func TestTarWithPatternMatchGrowingFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "archiver-growing-file")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	logPath := filepath.Join(tmpDir, "mongod.log")
+	initial := make([]byte, 1024*1024)
+	if err := os.WriteFile(logPath, initial, 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var buf bytes.Buffer
+	done := make(chan error, 1)
+	go func() {
+		done <- TarWithPatternMatch(tmpDir, `^mongod\.log.*`, &buf)
+	}()
+
+	for i := 0; i < 1000; i++ {
+		f, err := os.OpenFile(logPath, os.O_APPEND|os.O_WRONLY, 0644)
+		if err != nil {
+			continue
+		}
+		f.Write([]byte("more log data during archive\n"))
+		f.Close()
+	}
+
+	if err := <-done; err != nil {
+		t.Fatalf("TarWithPatternMatch: %v", err)
 	}
 }

--- a/ftdcarchiver/ftdcarchiver.go
+++ b/ftdcarchiver/ftdcarchiver.go
@@ -24,6 +24,8 @@ import (
 	"dcrcli/mongosh"
 )
 
+const MetricsFileSearchPattern = `^metrics\.[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}Z-[0-9]{5}$`
+
 type FTDCarchive struct {
 	Mongo             mongosh.CaptureGetMongoData
 	DiagnosticDirPath string
@@ -53,10 +55,9 @@ func (fa *FTDCarchive) createFTDCTarArchiveFile() error {
 }
 
 func (fa *FTDCarchive) archiveMetricsFiles() error {
-	metricsFileSearchPatternString := `^metrics.*`
 	err := archiver.TarWithPatternMatch(
 		fa.DiagnosticDirPath,
-		metricsFileSearchPatternString,
+		MetricsFileSearchPattern,
 		fa.FTDCArchiveFile,
 	)
 	if err != nil {

--- a/ftdcarchiver/remoteftdcarchive.go
+++ b/ftdcarchiver/remoteftdcarchive.go
@@ -55,10 +55,9 @@ func (fa *RemoteFTDCarchive) createFTDCTarArchiveFile() error {
 }
 
 func (fa *RemoteFTDCarchive) archiveMetricsFiles() error {
-	metricsFileSearchPatternString := `^metrics.*`
 	err := archiver.TarWithPatternMatch(
 		fa.TempOutputdir.Path(),
-		metricsFileSearchPatternString,
+		MetricsFileSearchPattern,
 		fa.FTDCArchiveFile,
 	)
 	if err != nil {


### PR DESCRIPTION
What was done

Fix noisy archiving warnings when collecting from live MongoDB nodes, and tighten FTDC file selection so generated archives are valid for downstream MRA analysis.
 * Log archiving: Cap tar copy at the file size seen at read time ({{{}io.LimitReader{}}}) so active {{mongod.log}} files that grow during collection no longer trigger {{{}archive/tar: write too long{}}}.
 * Transient FTDC paths: Silently skip expected races (e.g. {{metrics.interim}} removed/recreated during directory walk) instead of printing warnings.
 * FTDC archive content: Only include valid rotated FTDC files ({{{}metrics.YYYY-MM-DDTHH-MM-SSZ-NNNNN{}}}). Excludes active {{metrics.interim}} and junk names like {{metrics 2.interim}} that can break MRA/Alexandria.

{{-generate-config}} is unchanged in this PR (already on {{main}} via MIGRATION-841; ships in the next release).

 
<img width="823" height="438" alt="image" src="https://github.com/user-attachments/assets/a53fc46f-8c45-4ad2-82f5-40b883300216" />
