### PR TITLE
MIGRATION-832 - Update DCRcli prompt text based on feedback from the …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ outputs/
 .DS_Store
 .claude/
 daroNote.sh
+/dcrcli
+/cmd/

--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ chmod +x <binary-name>
 
 Run `./<binary-name> -h` for a full summary of flags.
 
+Flags:
+
+| Flag | Purpose |
+|------|---------|
+| `-config path` | Load connection details from a JSON config file (recommended). |
+| `-generate-config path` | Write a sample config file to `path` and exit. |
+| `-collect-nodes mode` | Collection scope: `one-secondary`, `all-secondaries`, or `all-nodes`. |
+
 ### Config File (recommended)
 
 A config file lets you set all connection details upfront so you never have to re-enter them. If a run fails, the error message tells you exactly which field to fix — just update the file and re-run.
@@ -122,11 +130,11 @@ This writes a `dcrcli.config.json` file with placeholder values and prints a des
 | Field | Description |
 |-------|-------------|
 | `cluster_name` | Display name used for the output directory. |
-| `seed_host` | Hostname or IP of a seed mongod or mongos. Defaults to `localhost` if blank. |
+| `seed_host` | Reachable mongod/mongos used to discover other cluster members. Defaults to `localhost` if blank. |
 | `seed_port` | Port of the seed node. Defaults to `27017` if blank. |
-| `username` | MongoDB admin username. Leave blank for clusters without authentication. |
+| `username` | MongoDB admin username. Leave blank for clusters without authentication. If set, dcrcli prompts for a password at startup (password is never stored in the config file). |
 | `uri_options` | Extra URI connection options in `name=value&name2=value2` format. **Do not include `replicaSet` here** — dcrcli discovers topology itself. |
-| `ssh_username` | OS username for passwordless SSH to remote cluster nodes. Leave blank if all nodes are on the same machine as dcrcli. |
+| `ssh_username` | OS username for passwordless SSH/rsync to remote nodes (FTDC and logs). Leave blank if all nodes are on the same machine as dcrcli. |
 | `collect_nodes` | Which nodes to collect from: `one-secondary` (default), `all-secondaries`, or `all-nodes`. Leave blank to be prompted interactively. |
 
 **Step 3 — Run:**

--- a/collectnodes/collectnodes.go
+++ b/collectnodes/collectnodes.go
@@ -16,7 +16,6 @@
 package collectnodes
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"io"
@@ -24,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 
+	"dcrcli/termui"
 	"dcrcli/topologyfinder"
 )
 
@@ -93,34 +93,41 @@ func ParseMode(s string) (Mode, error) {
 
 // Prompt asks the user which collection scope to use.
 func Prompt(stdin io.Reader, stdout io.Writer) (Mode, error) {
-	reader := bufio.NewReader(stdin)
-	_, _ = fmt.Fprintln(stdout, "Choose which MongoDB nodes to collect from:")
-	_, _ = fmt.Fprintln(stdout, "  1) One secondary only (default)")
-	_, _ = fmt.Fprintln(stdout, "  2) All secondaries; if sharded, also one mongos and one config server")
-	_, _ = fmt.Fprintln(stdout, "  3) All discovered nodes (every mongod, all mongos, all config servers; may add load, storage usage)")
-	_, _ = fmt.Fprint(stdout, "Enter choice (1-3) [1]: ")
+	return PromptUI(termui.New(stdin, stdout))
+}
 
-	line, err := reader.ReadString('\n')
+// PromptUI asks the user which collection scope to use with the shared terminal UI.
+// Call ui.Header("Collection scope") before topology discovery when starting this section.
+func PromptUI(ui *termui.UI) (Mode, error) {
+	ui.Note("Which nodes should dcrcli collect diagnostic data from?")
+	ui.Menu([]string{
+		"One secondary only (default)",
+		"All secondaries (+ one mongos and one config server when sharded)",
+		"All discovered nodes (may add load and storage usage)",
+	})
+	ui.Blank()
+	line, err := ui.AskChoice("Choice [1]")
 	if err != nil {
 		return 0, err
 	}
-	line = strings.TrimSpace(strings.TrimSuffix(line, "\n"))
 	var mode Mode
+	var choice string
 	switch {
 	case line == "" || line == "1":
 		mode = ModeOneSecondary
+		choice = "1"
 	case line == "2":
 		mode = ModeAllSecondaries
+		choice = "2"
 	case line == "3":
 		mode = ModeAllNodes
+		choice = "3"
 	default:
 		return 0, fmt.Errorf("invalid choice %q: enter 1, 2, or 3", line)
 	}
-	if line == "" {
-		_, _ = fmt.Fprintf(stdout, "\nUsing default (1) — %s\n\n", mode.Description())
-	} else {
-		_, _ = fmt.Fprintf(stdout, "\nUsing choice %s — %s\n\n", line, mode.Description())
-	}
+	ui.Blank()
+	ui.Ok(fmt.Sprintf("Selected option %s — %s", choice, mode.Description()))
+	ui.Blank()
 	return mode, nil
 }
 
@@ -148,23 +155,22 @@ func StandalonePrimaryTargets(nodes []topologyfinder.ClusterNode) []topologyfind
 
 // PromptStandaloneCollectPrimary asks whether to collect from the standalone primary (y/N).
 func PromptStandaloneCollectPrimary(stdin io.Reader, stdout io.Writer) (bool, error) {
-	_, _ = fmt.Fprint(stdout, "Collect from this primary (standalone) anyway? [y/N]: ")
-	line, err := bufio.NewReader(stdin).ReadString('\n')
-	if err != nil {
-		return false, err
-	}
-	s := strings.ToLower(strings.TrimSpace(strings.TrimSuffix(line, "\n")))
-	return s == "y" || s == "yes", nil
+	ui := termui.New(stdin, stdout)
+	ui.Warn("A single MongoDB node was discovered and it is not a secondary (typical standalone).")
+	ui.Note(
+		"Options 1 and 2 normally avoid primaries; standalone has no secondary to collect from.",
+	)
+	return ui.AskYesNo("Collect from this primary (standalone) anyway?", true)
 }
 
 // ResolveMode returns the collection mode. Non-empty flagValue wins; otherwise on a TTY Prompt is used;
 // non-interactive stdin defaults to ModeOneSecondary without prompting.
-func ResolveMode(flagValue string, isTerminal bool, stdin io.Reader, stdout io.Writer) (Mode, error) {
+func ResolveMode(flagValue string, isTerminal bool, ui *termui.UI) (Mode, error) {
 	if strings.TrimSpace(flagValue) != "" {
 		return ParseMode(flagValue)
 	}
 	if isTerminal {
-		return Prompt(stdin, stdout)
+		return PromptUI(ui)
 	}
 	return ModeOneSecondary, nil
 }

--- a/collectnodes/collectnodes_test.go
+++ b/collectnodes/collectnodes_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"dcrcli/termui"
 	"dcrcli/topologyfinder"
 )
 
@@ -199,14 +200,14 @@ func TestSelectShardedAllSecondariesExtraMongosConfigSkipped(t *testing.T) {
 }
 
 func TestResolveModeFlagPrecedence(t *testing.T) {
-	m, err := ResolveMode("all-nodes", true, strings.NewReader("2\n"), &bytes.Buffer{})
+	m, err := ResolveMode("all-nodes", true, termui.New(strings.NewReader("2\n"), &bytes.Buffer{}))
 	if err != nil || m != ModeAllNodes {
 		t.Fatalf("flag should ignore prompt stdin: got %v, %v", m, err)
 	}
 }
 
 func TestResolveModeNonInteractiveDefault(t *testing.T) {
-	m, err := ResolveMode("", false, strings.NewReader(""), &bytes.Buffer{})
+	m, err := ResolveMode("", false, termui.New(strings.NewReader(""), &bytes.Buffer{}))
 	if err != nil || m != ModeOneSecondary {
 		t.Fatalf("non-TTY default: got %v, %v", m, err)
 	}

--- a/dcrconfig/dcrconfig.go
+++ b/dcrconfig/dcrconfig.go
@@ -26,7 +26,8 @@ type Config struct {
 	// ClusterName is the display name used for the output directory.
 	ClusterName string `json:"cluster_name"`
 
-	// SeedHost is the hostname or IP of a seed mongod or mongos node.
+	// SeedHost is the hostname or IP of one reachable mongod or mongos (localhost or remote)
+	// used to discover the rest of the cluster via hello / getShardMap. It is not a special MongoDB role.
 	SeedHost string `json:"seed_host"`
 
 	// SeedPort is the port of the seed node. Defaults to "27017" if empty.

--- a/fscopy/fscopy.go
+++ b/fscopy/fscopy.go
@@ -111,7 +111,7 @@ func (fcjwp *FSCopyJobWithPattern) StartCopyRemoteWithPattern() error {
 	// we invoke bash shell because the wildcards are interpretted by bash shell not the rsync program
 	fcjwp.Dcrlog.Debug(
 		fmt.Sprintf(
-			"preparing command rsync -az --include=%s --exclude=%s --progress %s@%s:%s/ %s",
+			"preparing command rsync -az --include=%s --exclude=%s %s@%s:%s/ %s",
 			filepattern,
 			excludepattern,
 			fcjwp.CopyJobDetails.Src.Username,
@@ -125,7 +125,7 @@ func (fcjwp *FSCopyJobWithPattern) StartCopyRemoteWithPattern() error {
 		"bash",
 		"-c",
 		fmt.Sprintf(
-			"rsync -az --include=%s --exclude=%s --progress %s@%s:%s/ %s",
+			"rsync -az --include=%s --exclude=%s %s@%s:%s/ %s",
 			filepattern,
 			excludepattern,
 			fcjwp.CopyJobDetails.Src.Username,
@@ -144,7 +144,6 @@ func (fcjwp *FSCopyJobWithPattern) StartCopyRemoteWithPattern() error {
     
 	//Executing the rsync command
 	fcjwp.Dcrlog.Debug("rsync command start")
-	termui.SSHAuthNotice()
 	err := cmd.Run()
     if err != nil {
         fcjwp.Dcrlog.Debug(
@@ -204,7 +203,7 @@ type FSCopyJob struct {
 func (fcj *FSCopyJob) StartCopyRemote() error {
 	// var cmd *exec.Cmd
 
-	fcj.Dcrlog.Debug(fmt.Sprintf("preparing command rsync -az --progress %s@%s:%s/ %s",
+	fcj.Dcrlog.Debug(fmt.Sprintf("preparing command rsync -az %s@%s:%s/ %s",
 		fcj.Src.Username,
 		fcj.Src.Hostname,
 		fcj.Src.Path,
@@ -213,7 +212,6 @@ func (fcj *FSCopyJob) StartCopyRemote() error {
 	cmd := exec.Command(
 		"rsync",
 		"-az",
-		"--progress",
 		fmt.Sprintf(`%s@%s:%s`,
 			fcj.Src.Username,
 			fcj.Src.Hostname,
@@ -230,7 +228,6 @@ func (fcj *FSCopyJob) StartCopyRemote() error {
 
 
     fcj.Dcrlog.Debug("starting rsync command")
-	termui.SSHAuthNotice()
 	err := cmd.Run()
     if err != nil {
         fcj.Dcrlog.Debug(fmt.Sprintf("error doing remote copy job wait %w", err))

--- a/fscopy/fscopy.go
+++ b/fscopy/fscopy.go
@@ -16,6 +16,7 @@ package fscopy
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -25,6 +26,25 @@ import (
 	"dcrcli/dcrlogger"
 	"dcrcli/termui"
 )
+
+// rsyncVanishedSources is rsync's "Partial transfer due to vanished source files".
+// MongoDB rotates diagnostic.data (and sometimes logs) while we copy, so this is
+// expected and the files that did transfer are still usable.
+const rsyncVanishedSources = 24
+
+func tolerateRsyncError(err error, log *dcrlogger.DCRLogger) error {
+	if err == nil {
+		return nil
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) && ee.ExitCode() == rsyncVanishedSources {
+		if log != nil {
+			log.Warn("rsync exit 24 (vanished source files); keeping copied FTDC/log files")
+		}
+		return nil
+	}
+	return err
+}
 
 type RemoteCred struct {
 	Username  string
@@ -136,53 +156,53 @@ func (fcjwp *FSCopyJobWithPattern) StartCopyRemoteWithPattern() error {
 
 	//commenting out the cmd.Stdout because it is being used to capture the output below.
 	//cmd.Stdout = fcjwp.CopyJobDetails.Output
-	
+
 	//Allow user to provide input if needed.
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
-    cmd.Stderr = os.Stderr
-    
+	cmd.Stderr = os.Stderr
+
 	//Executing the rsync command
 	fcjwp.Dcrlog.Debug("rsync command start")
-	err := cmd.Run()
-    if err != nil {
-        fcjwp.Dcrlog.Debug(
-            fmt.Sprintf("StartCopyRemoteWithPattern: error doing remote copy job wait %w", err),
-        )
-        return fmt.Errorf("StartCopyRemoteWithPattern: error doing remote copy job wait %w", err)
-    }
-    return nil
-
-    // Removing stderr pipe for now. cmd.StderrPipe() The error produced by the command will appear in real time in the terminal.
-/*	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return err
-	}
-
-	fcjwp.Dcrlog.Debug("rsync command start")
-	err = cmd.Start()
-	if err != nil {
-		return err
-	}
-
-	_, err = io.ReadAll(stderr)
-	if err != nil {
-		_ = cmd.Process.Kill()
-		fcjwp.Dcrlog.Debug(
-			fmt.Sprintf("StartCopyRemoteWithPattern: Error reading from stderr pipe %w", err),
-		)
-		return fmt.Errorf("StartCopyRemoteWithPattern: Error reading from stderr pipe %w", err)
-	}
-
-	err = cmd.Wait()
+	err := tolerateRsyncError(cmd.Run(), fcjwp.Dcrlog)
 	if err != nil {
 		fcjwp.Dcrlog.Debug(
-			fmt.Sprintf("StartCopyRemoteWithPattern: error doing remote copy job wait %w", err),
+			fmt.Sprintf("StartCopyRemoteWithPattern: error doing remote copy job wait %v", err),
 		)
 		return fmt.Errorf("StartCopyRemoteWithPattern: error doing remote copy job wait %w", err)
 	}
 	return nil
-*/
+
+	// Removing stderr pipe for now. cmd.StderrPipe() The error produced by the command will appear in real time in the terminal.
+	/*	stderr, err := cmd.StderrPipe()
+		if err != nil {
+			return err
+		}
+
+		fcjwp.Dcrlog.Debug("rsync command start")
+		err = cmd.Start()
+		if err != nil {
+			return err
+		}
+
+		_, err = io.ReadAll(stderr)
+		if err != nil {
+			_ = cmd.Process.Kill()
+			fcjwp.Dcrlog.Debug(
+				fmt.Sprintf("StartCopyRemoteWithPattern: Error reading from stderr pipe %w", err),
+			)
+			return fmt.Errorf("StartCopyRemoteWithPattern: Error reading from stderr pipe %w", err)
+		}
+
+		err = cmd.Wait()
+		if err != nil {
+			fcjwp.Dcrlog.Debug(
+				fmt.Sprintf("StartCopyRemoteWithPattern: error doing remote copy job wait %w", err),
+			)
+			return fmt.Errorf("StartCopyRemoteWithPattern: error doing remote copy job wait %w", err)
+		}
+		return nil
+	*/
 }
 
 // Copy job
@@ -223,43 +243,42 @@ func (fcj *FSCopyJob) StartCopyRemote() error {
 	//cmd.Stdout = fcj.Output
 	// Allow user to provide input if needed
 	cmd.Stdin = os.Stdin
-    cmd.Stdout = os.Stdout
-    cmd.Stderr = os.Stderr
-
-
-    fcj.Dcrlog.Debug("starting rsync command")
-	err := cmd.Run()
-    if err != nil {
-        fcj.Dcrlog.Debug(fmt.Sprintf("error doing remote copy job wait %w", err))
-        return fmt.Errorf("error doing remote copy job wait %w", err)
-    }
-    return nil
-
-/*	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return err
-	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 
 	fcj.Dcrlog.Debug("starting rsync command")
-	err = cmd.Start()
+	err := tolerateRsyncError(cmd.Run(), fcj.Dcrlog)
 	if err != nil {
-		return err
-	}
-
-	_, err = io.ReadAll(stderr)
-	if err != nil {
-		_ = cmd.Process.Kill()
-		fcj.Dcrlog.Debug(fmt.Sprintf("error reading from stderr pipe %w", err))
-		return fmt.Errorf("error reading from stderr pipe %w", err)
-	}
-
-	err = cmd.Wait()
-	if err != nil {
-		fcj.Dcrlog.Debug(fmt.Sprintf("error doing remote copy job wait %w", err))
+		fcj.Dcrlog.Debug(fmt.Sprintf("error doing remote copy job wait %v", err))
 		return fmt.Errorf("error doing remote copy job wait %w", err)
 	}
-
 	return nil
+
+	/*	stderr, err := cmd.StderrPipe()
+		if err != nil {
+			return err
+		}
+
+		fcj.Dcrlog.Debug("starting rsync command")
+		err = cmd.Start()
+		if err != nil {
+			return err
+		}
+
+		_, err = io.ReadAll(stderr)
+		if err != nil {
+			_ = cmd.Process.Kill()
+			fcj.Dcrlog.Debug(fmt.Sprintf("error reading from stderr pipe %w", err))
+			return fmt.Errorf("error reading from stderr pipe %w", err)
+		}
+
+		err = cmd.Wait()
+		if err != nil {
+			fcj.Dcrlog.Debug(fmt.Sprintf("error doing remote copy job wait %w", err))
+			return fmt.Errorf("error doing remote copy job wait %w", err)
+		}
+
+		return nil
 	*/
 
 }

--- a/fscopy/fscopy.go
+++ b/fscopy/fscopy.go
@@ -15,16 +15,15 @@
 package fscopy
 
 import (
-	"bufio"
 	"bytes"
 	"fmt"
-	//"io"
 	"os"
 	"os/exec"
 	"strings"
 
 	"dcrcli/dcrconfig"
 	"dcrcli/dcrlogger"
+	"dcrcli/termui"
 )
 
 type RemoteCred struct {
@@ -33,28 +32,31 @@ type RemoteCred struct {
 	Dcrlog    *dcrlogger.DCRLogger
 }
 
-func (rc *RemoteCred) Get() error {
-	reader := bufio.NewReader(os.Stdin)
-	fmt.Println(
-		"Enter ssh User for remote copy. Leave Blank for cluster without remote nodes): ",
+func (rc *RemoteCred) Get(ui *termui.UI) error {
+	ui.BeginStep("SSH username")
+	ui.Note(
+		"Only needed when MongoDB runs on other machines — your login there to copy FTDC and log files.",
+		"Leave blank if every MongoDB node is on this machine. Help: "+termui.READMEPrerequisitesURL,
 	)
-	username, err := reader.ReadString('\n')
+	username, err := ui.AskInput("Username")
 	if err != nil {
 		return err
 	}
 
-	rc.Username = strings.TrimSuffix(username, "\n")
+	rc.Username = username
 	rc.Dcrlog.Debug(fmt.Sprintf("passwordless ssh username %s:", rc.Username))
 
 	if rc.Username == "" {
-		println("WARNING: PasswordLess SSH Username is empty assuming all nodes local")
+		ui.Warn("SSH username left empty; assuming all nodes are local")
 		rc.Available = false
 		rc.Dcrlog.Debug("passwordless ssh username left blank assuming all nodes local")
 	} else {
 		rc.Available = true
 		rc.Dcrlog.Debug("passwordless ssh username provided")
+		ui.Ok("SSH username: " + rc.Username)
 	}
 
+	ui.Blank()
 	return nil
 }
 
@@ -142,7 +144,7 @@ func (fcjwp *FSCopyJobWithPattern) StartCopyRemoteWithPattern() error {
     
 	//Executing the rsync command
 	fcjwp.Dcrlog.Debug("rsync command start")
-    fmt.Println("Please add your password for SSH connection:")
+	termui.SSHAuthNotice()
 	err := cmd.Run()
     if err != nil {
         fcjwp.Dcrlog.Debug(
@@ -228,8 +230,7 @@ func (fcj *FSCopyJob) StartCopyRemote() error {
 
 
     fcj.Dcrlog.Debug("starting rsync command")
-	// Ask for SSH password
-    fmt.Println("Please add your password for SSH connection ")
+	termui.SSHAuthNotice()
 	err := cmd.Run()
     if err != nil {
         fcj.Dcrlog.Debug(fmt.Sprintf("error doing remote copy job wait %w", err))

--- a/fscopy/fscopy_test.go
+++ b/fscopy/fscopy_test.go
@@ -16,6 +16,7 @@ package fscopy
 
 import (
 	"bytes"
+	"os/exec"
 	"testing"
 )
 
@@ -27,18 +28,17 @@ import (
 // - local copy job
 func TestStartCopyLocal(t *testing.T) {
 	fcj := FSCopyJob{
-		SourceDir{
-			true,
-			[]byte(`/Users/nishant/myprojects/testclusters/standalone/data/db/diagnostic.data/`),
-			[]byte(``),
-			0,
-			[]byte(`ubuntu`),
+		Src: SourceDir{
+			IsLocal:  true,
+			Path:     []byte(`/Users/nishant/myprojects/testclusters/standalone/data/db/diagnostic.data/`),
+			Hostname: []byte(``),
+			Username: []byte(`ubuntu`),
 		},
-		DestDir{
-			[]byte(`/Users/nishant/myprojects/dcrcliProject/branches/remotecopier/dcrcli/outputs`),
+		Dst: DestDir{
+			Path: []byte(`/Users/nishant/myprojects/dcrcliProject/branches/remotecopier/dcrcli/outputs`),
 		},
-		"N",
-		&bytes.Buffer{},
+		State:  "N",
+		Output: &bytes.Buffer{},
 	}
 	err := fcj.StartCopy()
 	if err != nil {
@@ -69,3 +69,25 @@ func TestStartCopyRemote(t *testing.T) {
 	}
 }
 */
+
+func TestTolerateRsyncVanishedSources(t *testing.T) {
+	if err := tolerateRsyncError(nil, nil); err != nil {
+		t.Fatalf("nil error should pass through, got %v", err)
+	}
+
+	err24 := exec.Command("sh", "-c", "exit 24").Run()
+	if err24 == nil {
+		t.Fatal("expected sh to exit 24")
+	}
+	if err := tolerateRsyncError(err24, nil); err != nil {
+		t.Fatalf("rsync exit 24 should be treated as success, got %v", err)
+	}
+
+	err23 := exec.Command("sh", "-c", "exit 23").Run()
+	if err23 == nil {
+		t.Fatal("expected sh to exit 23")
+	}
+	if err := tolerateRsyncError(err23, nil); err == nil {
+		t.Fatal("rsync exit 23 should remain a failure")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,13 @@ module dcrcli
 go 1.21.4
 
 require (
-	github.com/briandowns/spinner v1.23.1 // indirect
-	github.com/fatih/color v1.7.0 // indirect
-	github.com/google/uuid v1.5.0 // indirect
+	github.com/briandowns/spinner v1.23.1
+	github.com/fatih/color v1.7.0
+	golang.org/x/term v0.15.0
+)
+
+require (
 	github.com/mattn/go-colorable v0.1.2 // indirect
 	github.com/mattn/go-isatty v0.0.8 // indirect
 	golang.org/x/sys v0.15.0 // indirect
-	golang.org/x/term v0.15.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/briandowns/spinner v1.23.1 h1:t5fDPmScwUjozhDj4FA46p5acZWIPXYE30qW2Pt
 github.com/briandowns/spinner v1.23.1/go.mod h1:LaZeM4wm2Ywy6vO571mvhQNRcWfRUnXOs0RcKV0wYKM=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
-github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=

--- a/main.go
+++ b/main.go
@@ -497,7 +497,7 @@ func main() {
 		c.Outputdir = &outputdir
 
 		dcrlog.Info("Running getMongoData/mongoWellnessChecker")
-		err = cp.RunTask(0, "getMongoData", func() error {
+		err = cp.RunTask(0, nil, func() error {
 			return c.RunMongoShellWithEval()
 		})
 		if err != nil {
@@ -543,7 +543,7 @@ func main() {
 			)
 
 			dcrlog.Info("Running FTDC Archiving")
-			err = cp.RunTask(1, "FTDC data", func() error {
+			err = cp.RunTask(1, nil, func() error {
 				ftdcarchive := ftdcarchiver.FTDCarchive{}
 				ftdcarchive.Mongo.S = &cred
 				ftdcarchive.Outputdir = &outputdir
@@ -554,7 +554,7 @@ func main() {
 			}
 
 			dcrlog.Info("Running mongo log Archiving")
-			err = cp.RunTask(2, "mongod logs", func() error {
+			err = cp.RunTask(2, nil, func() error {
 				logarchive := mongologarchiver.MongoDLogarchive{}
 				logarchive.Mongo.S = &cred
 				logarchive.Outputdir = &outputdir
@@ -586,9 +586,18 @@ func main() {
 					)
 				}
 
+				sshBase := termui.SSHTarget{
+					User:      remoteCred.Username,
+					Host:      cred.Currentmongodhost,
+					MongoHost: host.Hostname,
+					MongoPort: host.Port,
+				}
+
 				dcrlog.Info("Running FTDC Archiving")
 				var buffer bytes.Buffer
-				err = cp.RunTask(1, "FTDC data", func() error {
+				ftdcSSH := sshBase
+				ftdcSSH.Purpose = "FTDC data"
+				err = cp.RunTask(1, &ftdcSSH, func() error {
 					remoteFTDCArchiver := ftdcarchiver.RemoteFTDCarchive{}
 					remoteFTDCArchiver.RemoteCopyJob = &remotecopyJob
 					remoteFTDCArchiver.Mongo.S = &cred
@@ -615,7 +624,9 @@ func main() {
 				remotecopyJobWithPattern.CopyJobDetails = &remotecopyJob
 
 				dcrlog.Info("Running mongo log Archiving")
-				err = cp.RunTask(2, "mongod logs", func() error {
+				logsSSH := sshBase
+				logsSSH.Purpose = "mongod logs"
+				err = cp.RunTask(2, &logsSSH, func() error {
 					remoteLogArchiver := mongologarchiver.RemoteMongoDLogarchive{}
 					remoteLogArchiver.RemoteCopyJob = &remotecopyJobWithPattern
 					remoteLogArchiver.Mongo.S = &cred

--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ import (
 	"dcrcli/mongocredentials"
 	"dcrcli/mongologarchiver"
 	"dcrcli/mongosh"
+	"dcrcli/termui"
 	"dcrcli/topologyfinder"
 )
 
@@ -138,6 +139,7 @@ func abortIfAnyNodeUnhealthy(
 	nodes []topologyfinder.ClusterNode,
 	phase string,
 	dcrlog *dcrlogger.DCRLogger,
+	ui *termui.UI,
 ) {
 	dcrlog.Info(
 		fmt.Sprintf("Health check (%s): probing %d cluster node(s)", phase, len(nodes)),
@@ -151,24 +153,20 @@ func abortIfAnyNodeUnhealthy(
 		return
 	}
 
-	fmt.Printf("\n")
-	fmt.Println("######################################################################")
-	fmt.Println("#                                 ERROR                              #")
-	fmt.Println("######################################################################")
-	fmt.Printf("\nCluster health check failed (%s).\n", phase)
-	fmt.Println("The following MongoDB node(s) are unreachable:")
+	unhealthyLines := make([]string, 0, len(unhealthy)+3)
+	unhealthyLines = append(unhealthyLines, fmt.Sprintf("Cluster health check failed (%s).", phase))
+	unhealthyLines = append(unhealthyLines, "The following MongoDB node(s) are unreachable:")
 	for _, u := range unhealthy {
-		fmt.Printf("  - %s:%d\n", u.Hostname, u.Port)
+		unhealthyLines = append(unhealthyLines, fmt.Sprintf("  - %s:%d", u.Hostname, u.Port))
 	}
-	fmt.Println()
-	fmt.Println(
+	unhealthyLines = append(unhealthyLines,
 		"dcrcli runs getMongoData against live clusters; refusing to proceed while any cluster node is down to avoid added production risk.",
+		"Verify all members are healthy (e.g. rs.status()) and retry.",
 	)
-	fmt.Println("Verify all members are healthy (e.g. rs.status()) and retry.")
 	if lastErr != nil {
-		fmt.Printf("Last connection error: %v\n", lastErr)
+		unhealthyLines = append(unhealthyLines, fmt.Sprintf("Last connection error: %v", lastErr))
 	}
-	fmt.Println()
+	ui.ErrorBanner("ERROR", unhealthyLines...)
 
 	dcrlog.Error(
 		fmt.Sprintf(
@@ -182,27 +180,30 @@ func abortIfAnyNodeUnhealthy(
 func main() {
 	var err error
 
-	collectNodesFlag := flag.String(
-		"collect-nodes",
-		"",
-		`Which members to collect from: "one-secondary" (default when non-interactive; one SECONDARY only), "all-secondaries" (every SECONDARY; if sharded, also one mongos and one config server), or "all-nodes" (every discovered host: all mongods, all mongos, all config). If omitted and stdin is a terminal, you are prompted.`,
-	)
-	configFile := flag.String(
-		"config",
-		"",
-		"Path to a JSON config file with connection details. Use -generate-config to create a sample.",
-	)
-	generateConfig := flag.String(
-		"generate-config",
-		"",
-		"Write a sample config file to the given path and exit. Example: ./dcrcli -generate-config dcrcli.config.json",
-	)
+	collectNodesFlag := flag.String("collect-nodes", "", "")
+	configFile := flag.String("config", "", "")
+	generateConfig := flag.String("generate-config", "", "")
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: %s [options]\n\n", os.Args[0])
-		fmt.Fprintf(os.Stderr, "Discover MongoDB cluster nodes from a seed and collect diagnostic data (getMongoData, FTDC, logs).\n")
-		fmt.Fprintf(os.Stderr, "By default a single SECONDARY is collected only; use -collect-nodes for all-secondaries (adds one mongos + one config when sharded) or all-nodes.\n\n")
-		fmt.Fprintf(os.Stderr, "Options:\n")
-		flag.PrintDefaults()
+		w := os.Stderr
+		bin := os.Args[0]
+		fmt.Fprintf(w, "Usage: %s [options]\n\n", bin)
+		fmt.Fprintf(w, "Discover MongoDB cluster nodes from a seed and collect diagnostic data\n")
+		fmt.Fprintf(w, "(getMongoData, FTDC, logs). Default collection scope: one SECONDARY only.\n\n")
+		fmt.Fprintf(w, "Options:\n\n")
+		fmt.Fprintf(w, "  -collect-nodes mode\n")
+		fmt.Fprintf(w, "        Which members to collect from:\n")
+		fmt.Fprintf(w, "          one-secondary     one SECONDARY only (default when non-interactive)\n")
+		fmt.Fprintf(w, "          all-secondaries   every SECONDARY; if sharded, also one mongos + one config\n")
+		fmt.Fprintf(w, "          all-nodes         every discovered host (mongod, mongos, config)\n")
+		fmt.Fprintf(w, "        Omit to be prompted when stdin is a terminal.\n")
+		fmt.Fprintf(w, "        Example: %s -collect-nodes all-secondaries\n\n", bin)
+		fmt.Fprintf(w, "  -config path\n")
+		fmt.Fprintf(w, "        JSON config file with connection details.\n")
+		fmt.Fprintf(w, "        Create a sample with -generate-config.\n")
+		fmt.Fprintf(w, "        Example: %s -config dcrcli.config.json\n\n", bin)
+		fmt.Fprintf(w, "  -generate-config path\n")
+		fmt.Fprintf(w, "        Write a sample config file to path and exit.\n")
+		fmt.Fprintf(w, "        Example: %s -generate-config dcrcli.config.json\n", bin)
 	}
 	flag.Parse()
 
@@ -210,17 +211,17 @@ func main() {
 		if err := dcrconfig.GenerateSample(*generateConfig); err != nil {
 			log.Fatal("Failed to write sample config file:", err)
 		}
-		fmt.Println("Sample config written to:", *generateConfig)
-		fmt.Println()
-		fmt.Println("Fields:")
-		fmt.Println("  cluster_name   — display name for the output directory")
-		fmt.Println("  seed_host      — hostname or IP of a seed mongod/mongos")
-		fmt.Println("  seed_port      — port of the seed node (default 27017)")
-		fmt.Println("  username       — MongoDB admin username (blank = no auth)")
-		fmt.Println("  password       — MongoDB admin password (blank = no auth)")
-		fmt.Println("  uri_options    — extra URI options e.g. tls=true (no replicaSet)")
-		fmt.Println("  ssh_username   — OS user for passwordless SSH to remote nodes (blank = all local)")
-		fmt.Println("  collect_nodes  — one-secondary | all-secondaries | all-nodes (blank = prompt)")
+		genUI := termui.NewDefault()
+		genUI.Header("Sample config created")
+		genUI.Ok("Sample config written to: " + *generateConfig)
+		genUI.Section("Fields")
+		genUI.KeyValue("cluster_name", "display name for the output directory")
+		genUI.KeyValue("seed_host", "reachable mongod/mongos used to discover other members (blank = localhost)")
+		genUI.KeyValue("seed_port", "TCP port of the seed listener (blank = 27017)")
+		genUI.KeyValue("username", "MongoDB admin username (blank = no auth; password is prompted, never stored)")
+		genUI.KeyValue("uri_options", "extra URI options e.g. tls=true (do not include replicaSet)")
+		genUI.KeyValue("ssh_username", "OS user for SSH/rsync to remote nodes for FTDC and logs (blank = local only)")
+		genUI.KeyValue("collect_nodes", "one-secondary | all-secondaries | all-nodes (blank = prompt)")
 		os.Exit(0)
 	}
 
@@ -243,7 +244,8 @@ func main() {
 		dcrlog.SetLogLevel(slog.LevelDebug)
 	}
 
-	fmt.Println("DCR Log file:", dcrlog.Path())
+	ui := termui.NewDefault()
+	ui.Info("DCR log file: " + dcrlog.Path())
 
 	cred := mongocredentials.Mongocredentials{}
 	cred.Dcrlog = &dcrlog
@@ -262,42 +264,41 @@ func main() {
 			log.Fatal("Failed to load config file:", err)
 		}
 
-		fmt.Println("Loading config from:", *configFile)
-		fmt.Printf("  cluster_name:  %s\n", cfg.ClusterName)
-		fmt.Printf("  seed_host:     %s\n", cfg.SeedHost)
-		fmt.Printf("  seed_port:     %s\n", cfg.SeedPort)
+		ui.Header("Config file")
+		ui.Info("Loading config from: " + *configFile)
+		ui.KeyValue("cluster_name", cfg.ClusterName)
+		ui.KeyValue("seed_host", cfg.SeedHost)
+		ui.KeyValue("seed_port", cfg.SeedPort)
 		if cfg.Username != "" {
-			fmt.Printf("  username:      %s\n", cfg.Username)
+			ui.KeyValue("username", cfg.Username)
 		} else {
-			fmt.Println("  username:      (none — no-auth cluster)")
+			ui.KeyValue("username", "(none — no-auth cluster)")
 		}
 		if cfg.Username != "" {
-			fmt.Println("  password:      [will prompt interactively]")
+			ui.KeyValue("password", "[will prompt interactively]")
 		} else {
-			fmt.Println("  password:      (none — no-auth cluster)")
+			ui.KeyValue("password", "(none — no-auth cluster)")
 		}
 		if cfg.URIOptions != "" {
-			fmt.Printf("  uri_options:   %s\n", cfg.URIOptions)
+			ui.KeyValue("uri_options", cfg.URIOptions)
 		} else {
-			fmt.Println("  uri_options:   (none)")
+			ui.KeyValue("uri_options", "(none)")
 		}
 		if cfg.SSHUsername != "" {
-			fmt.Printf("  ssh_username:  %s\n", cfg.SSHUsername)
+			ui.KeyValue("ssh_username", cfg.SSHUsername)
 		} else {
-			fmt.Println("  ssh_username:  (none — all nodes treated as local)")
+			ui.KeyValue("ssh_username", "(none — all nodes treated as local)")
 		}
 		if cfg.CollectNodes != "" {
-			fmt.Printf("  collect_nodes: %s\n", cfg.CollectNodes)
+			ui.KeyValue("collect_nodes", cfg.CollectNodes)
 		} else {
-			fmt.Println("  collect_nodes: (will prompt interactively)")
+			ui.KeyValue("collect_nodes", "(will prompt interactively)")
 		}
-		fmt.Println()
+		ui.Blank()
 
-		if err := cred.GetFromConfig(cfg); err != nil {
+		if err := cred.GetFromConfig(ui, cfg); err != nil {
 			dcrlog.Error(err.Error())
-			fmt.Println()
-			fmt.Println("Config validation failed:", err)
-			fmt.Println("Fix the value in", *configFile, "and re-run.")
+			ui.ErrorBanner("Config validation failed", err.Error(), "Fix the value in "+*configFile+" and re-run.")
 			os.Exit(1)
 		}
 
@@ -307,39 +308,36 @@ func main() {
 			collectModeStr = cfg.CollectNodes
 		}
 	} else {
-		err = cred.Get()
+		ui.SetStepTotal(7)
+		err = cred.Get(ui)
 		if err != nil {
 			dcrlog.Error(err.Error())
 			log.Fatal("Error while getting DB credentials aborting!")
 		}
-		remoteCred.Get()
+		err = remoteCred.Get(ui)
+		if err != nil {
+			dcrlog.Error(err.Error())
+			log.Fatal("Error while getting SSH credentials aborting!")
+		}
+	}
+
+	isTerm := term.IsTerminal(int(syscall.Stdin))
+	needCollectPrompt := isTerm && strings.TrimSpace(collectModeStr) == ""
+
+	dcrlog.Info("Probing cluster topology")
+	if needCollectPrompt {
+		ui.EndStepSession()
+		ui.Blank()
+		ui.Header("Collection scope")
+		ui.Info("Discovering cluster topology from seed node…")
+	} else {
+		ui.Info("Discovering cluster topology from seed node…")
 	}
 
 	s := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
+	s.Prefix = "  "
+	s.Suffix = " Probing cluster…"
 	s.Start()
-
-	outputdir := dcroutdir.DCROutputDir{}
-	outputdir.OutputPrefix = checkEmptyDirectory("./outputs/" + cred.Clustername + "/")
-
-	dcrlog.Info(
-		fmt.Sprintf(
-			"Seed Host: %s, Seed Port: %s", cred.Seedmongodhost, cred.Seedmongodport,
-		),
-	)
-
-	dcrlog.Info(
-		fmt.Sprintf(
-			"DCR outputs directory: %s", outputdir.OutputPrefix,
-		),
-	)
-
-	dcrlog.Info(
-		fmt.Sprintf(
-			"remote creds: %v, %v", remoteCred.Username, remoteCred.Available,
-		),
-	)
-
-	dcrlog.Info("Probing cluster topology")
 
 	clustertopology := topologyfinder.TopologyFinder{}
 	clustertopology.Dcrlog = &dcrlog
@@ -366,10 +364,30 @@ func main() {
 
 	// Stop spinner so terminal echo and the collect-nodes prompt are visible (spinner redraw would hide input).
 	s.Stop()
-	fmt.Println()
+	ui.Blank()
 
-	isTerm := term.IsTerminal(int(syscall.Stdin))
-	collectMode, err := collectnodes.ResolveMode(collectModeStr, isTerm, os.Stdin, os.Stdout)
+	outputdir := dcroutdir.DCROutputDir{}
+	outputdir.OutputPrefix = checkEmptyDirectory("./outputs/" + cred.Clustername + "/")
+
+	dcrlog.Info(
+		fmt.Sprintf(
+			"Seed Host: %s, Seed Port: %s", cred.Seedmongodhost, cred.Seedmongodport,
+		),
+	)
+
+	dcrlog.Info(
+		fmt.Sprintf(
+			"DCR outputs directory: %s", outputdir.OutputPrefix,
+		),
+	)
+
+	dcrlog.Info(
+		fmt.Sprintf(
+			"remote creds: %v, %v", remoteCred.Username, remoteCred.Available,
+		),
+	)
+
+	collectMode, err := collectnodes.ResolveMode(collectModeStr, isTerm, ui)
 	if err != nil {
 		dcrlog.Error(err.Error())
 		log.Fatal("Invalid collection scope:", err)
@@ -383,9 +401,6 @@ func main() {
 			isTerm &&
 			strings.TrimSpace(collectModeStr) == "" &&
 			collectnodes.LooksLikeStandaloneMongod(nodes) {
-			fmt.Println()
-			fmt.Println("WARNING: A single MongoDB node was discovered and it is not a secondary (typical standalone).")
-			fmt.Println("Options 1 and 2 normally avoid primaries; standalone has no secondary to collect from.")
 			ok, perr := collectnodes.PromptStandaloneCollectPrimary(os.Stdin, os.Stdout)
 			if perr != nil {
 				dcrlog.Error(perr.Error())
@@ -394,8 +409,8 @@ func main() {
 			if ok {
 				collectTargets = collectnodes.StandalonePrimaryTargets(nodes)
 				dcrlog.Info("User confirmed collection from standalone primary")
-				fmt.Println("Proceeding: data will be collected from this primary (standalone).")
-				fmt.Println()
+				ui.Ok("Proceeding: data will be collected from this primary (standalone).")
+				ui.Blank()
 			} else {
 				log.Fatal("Aborted. For standalone use option 3 (all nodes), or pass --collect-nodes=all-nodes, or add a replica set secondary.")
 			}
@@ -422,12 +437,6 @@ func main() {
 			len(collectTargets),
 		),
 	)
-	fmt.Printf(
-		"\nCollecting from %d node(s); scope %s — %s\n",
-		len(collectTargets),
-		collectMode.String(),
-		collectMode.Description(),
-	)
 	for _, t := range collectTargets {
 		dcrlog.Info(fmt.Sprintf("Collection target: %s:%d (%s)", t.Hostname, t.Port, t.ReplicaState))
 	}
@@ -436,27 +445,30 @@ func main() {
 	// member of the discovered topology is already unreachable. getMongoData is run
 	// against live (typically production) clusters, so taking on additional risk while
 	// a node is down is unacceptable.
-	abortIfAnyNodeUnhealthy(clustertopology.Allnodes.Nodes, "pre-collection", &dcrlog)
+	abortIfAnyNodeUnhealthy(clustertopology.Allnodes.Nodes, "pre-collection", &dcrlog, ui)
 
-	s.Start()
+	const collectionTasksPerNode = 3
+	collectionHosts := make([]termui.CollectionHost, len(collectTargets))
+	for i, t := range collectTargets {
+		collectionHosts[i] = termui.CollectionHost{Hostname: t.Hostname, Port: t.Port}
+	}
+	cp := ui.CollectionStart(collectionHosts, collectionTasksPerNode)
 
-	for _, host := range collectTargets {
+	for i, host := range collectTargets {
 
 		// Per-iteration cluster-wide health gate: re-probe every node before moving on
 		// to the next collection target so we never stack additional load on a cluster
 		// that has degraded mid-run.
-		abortIfAnyNodeUnhealthy(clustertopology.Allnodes.Nodes, "pre-iteration", &dcrlog)
+		abortIfAnyNodeUnhealthy(clustertopology.Allnodes.Nodes, "pre-iteration", &dcrlog, ui)
 
 		dcrlog.Info(fmt.Sprintf("Collecting logs for MongoDB node - host: %s, port: %d", host.Hostname, host.Port))
-		fmt.Printf("\nCollecting logs for MongoDB node %s:%d\n", host.Hostname, host.Port)
+		cp.BeginNode(i)
 		// determine if the data collection should abort due to not enough free space
 		// we keep approx 1GB as limit
 		fsHasFreeSpace, err := hasFreeSpace()
 		if err != nil {
 			dcrlog.Warn("Warning cannot check free space for data collection.")
-			fmt.Println(
-				"WARNING: Cannot check free space for data collection monitor free space e.g. df -h output",
-			)
+			ui.Warn("Cannot check free space for data collection; monitor free space (e.g. df -h output)")
 		} else {
 			if !fsHasFreeSpace {
 				log.Fatal("aborting because not enough free space for data collection to continue")
@@ -485,7 +497,9 @@ func main() {
 		c.Outputdir = &outputdir
 
 		dcrlog.Info("Running getMongoData/mongoWellnessChecker")
-		err = c.RunMongoShellWithEval()
+		err = cp.RunTask(0, "getMongoData", func() error {
+			return c.RunMongoShellWithEval()
+		})
 		if err != nil {
 			dcrlog.Error(fmt.Sprintf("Error Running getMongoData %v", err))
 		}
@@ -495,11 +509,11 @@ func main() {
 		if !isAliveAfter && isAliveBefore {
 			dcrlog.Error(fmt.Sprintf("MongoDB node %s:%d became unreachable after collecting getMongoData.\n %v", host.Hostname, host.Port, err))
 
-			fmt.Printf("\n")
-			fmt.Println("######################################################################")
-			fmt.Println("#                                 ERROR                              #")
-			fmt.Println("######################################################################")
-			fmt.Printf("\nMongoDB node %s:%d is unreachable post getMongoData collection.\nTerminating the execution!\n\n", host.Hostname, host.Port)
+			ui.ErrorBanner(
+				"ERROR",
+				fmt.Sprintf("MongoDB node %s:%d is unreachable post getMongoData collection.", host.Hostname, host.Port),
+				"Terminating the execution!",
+			)
 
 			dcrlog.Error("Terminating DCR-CLI execution")
 			os.Exit(1)
@@ -529,24 +543,26 @@ func main() {
 			)
 
 			dcrlog.Info("Running FTDC Archiving")
-			ftdcarchive := ftdcarchiver.FTDCarchive{}
-			ftdcarchive.Mongo.S = &cred
-			ftdcarchive.Outputdir = &outputdir
-			err = ftdcarchive.Start()
+			err = cp.RunTask(1, "FTDC data", func() error {
+				ftdcarchive := ftdcarchiver.FTDCarchive{}
+				ftdcarchive.Mongo.S = &cred
+				ftdcarchive.Outputdir = &outputdir
+				return ftdcarchive.Start()
+			})
 			if err != nil {
 				dcrlog.Error(fmt.Sprintf("Error in FTDCArchive: %v", err))
-				// log.Fatal("Error in FTDCArchive: ", err)
 			}
 
 			dcrlog.Info("Running mongo log Archiving")
-			logarchive := mongologarchiver.MongoDLogarchive{}
-			logarchive.Mongo.S = &cred
-			logarchive.Outputdir = &outputdir
-			logarchive.Dcrlog = &dcrlog
-			err = logarchive.Start()
+			err = cp.RunTask(2, "mongod logs", func() error {
+				logarchive := mongologarchiver.MongoDLogarchive{}
+				logarchive.Mongo.S = &cred
+				logarchive.Outputdir = &outputdir
+				logarchive.Dcrlog = &dcrlog
+				return logarchive.Start()
+			})
 			if err != nil {
 				dcrlog.Error(fmt.Sprintf("Error in LogArchive: %v", err))
-				// log.Fatal("Error in LogArchive:", err)
 			}
 
 		} else {
@@ -555,12 +571,6 @@ func main() {
 
 				remotecopyJob := fscopy.FSCopyJob{}
 				remotecopyJob.Dcrlog = &dcrlog
-
-				dcrlog.Info("Running FTDC Archiving")
-				remoteFTDCArchiver := ftdcarchiver.RemoteFTDCarchive{}
-				remoteFTDCArchiver.RemoteCopyJob = &remotecopyJob
-				remoteFTDCArchiver.Mongo.S = &cred
-				remoteFTDCArchiver.Outputdir = &outputdir
 
 				tempdir := dcroutdir.DCROutputDir{}
 				tempdir.OutputPrefix = "./outputs/temp/" + cred.Clustername + "/"
@@ -576,22 +586,25 @@ func main() {
 					)
 				}
 
-				remoteFTDCArchiver.TempOutputdir = &tempdir
-				remoteFTDCArchiver.RemoteCopyJob.Src.IsLocal = false
-				remoteFTDCArchiver.RemoteCopyJob.Src.Username = []byte(remoteCred.Username)
-				remoteFTDCArchiver.RemoteCopyJob.Src.Hostname = []byte(cred.Currentmongodhost)
-
+				dcrlog.Info("Running FTDC Archiving")
 				var buffer bytes.Buffer
-				remoteFTDCArchiver.RemoteCopyJob.Output = &buffer
-
-				remoteFTDCArchiver.RemoteCopyJob.Dst.Path = []byte(
-					remoteFTDCArchiver.TempOutputdir.Path(),
-				)
-
-				err = remoteFTDCArchiver.Start()
+				err = cp.RunTask(1, "FTDC data", func() error {
+					remoteFTDCArchiver := ftdcarchiver.RemoteFTDCarchive{}
+					remoteFTDCArchiver.RemoteCopyJob = &remotecopyJob
+					remoteFTDCArchiver.Mongo.S = &cred
+					remoteFTDCArchiver.Outputdir = &outputdir
+					remoteFTDCArchiver.TempOutputdir = &tempdir
+					remoteFTDCArchiver.RemoteCopyJob.Src.IsLocal = false
+					remoteFTDCArchiver.RemoteCopyJob.Src.Username = []byte(remoteCred.Username)
+					remoteFTDCArchiver.RemoteCopyJob.Src.Hostname = []byte(cred.Currentmongodhost)
+					remoteFTDCArchiver.RemoteCopyJob.Output = &buffer
+					remoteFTDCArchiver.RemoteCopyJob.Dst.Path = []byte(
+						remoteFTDCArchiver.TempOutputdir.Path(),
+					)
+					return remoteFTDCArchiver.Start()
+				})
 				if err != nil {
 					dcrlog.Error(fmt.Sprintf("Error in Remote FTDC Archive for this node: %v", err))
-					// log.Fatal("Error in Remote FTDC Archive: ", err)
 				}
 
 				dcrlog.Debug(fmt.Sprintf("remote copy job output %s:", buffer.String()))
@@ -602,28 +615,39 @@ func main() {
 				remotecopyJobWithPattern.CopyJobDetails = &remotecopyJob
 
 				dcrlog.Info("Running mongo log Archiving")
-				remoteLogArchiver := mongologarchiver.RemoteMongoDLogarchive{}
-				remoteLogArchiver.RemoteCopyJob = &remotecopyJobWithPattern
-				remoteLogArchiver.Mongo.S = &cred
-				remoteLogArchiver.Outputdir = &outputdir
-				remoteLogArchiver.TempOutputdir = &tempdir
-				remoteLogArchiver.Dcrlog = &dcrlog
-
-				err = remoteLogArchiver.Start()
+				err = cp.RunTask(2, "mongod logs", func() error {
+					remoteLogArchiver := mongologarchiver.RemoteMongoDLogarchive{}
+					remoteLogArchiver.RemoteCopyJob = &remotecopyJobWithPattern
+					remoteLogArchiver.Mongo.S = &cred
+					remoteLogArchiver.Outputdir = &outputdir
+					remoteLogArchiver.TempOutputdir = &tempdir
+					remoteLogArchiver.Dcrlog = &dcrlog
+					return remoteLogArchiver.Start()
+				})
 				if err != nil {
 					dcrlog.Error(fmt.Sprintf("Error in Remote Log Archive for this node: %v", err))
-					// log.Fatal("Error in Remote Log Archive: ", err)
 				}
 				dcrlog.Debug(fmt.Sprintf("remote copy job output %s:", buffer.String()))
 				remotecopyJob.Output.Reset()
+			} else {
+				dcrlog.Warn(
+					fmt.Sprintf(
+						"%s does not run on the dcrcli host and no SSH username was set; skipping FTDC and mongod log copy for this node (getMongoData was still collected)",
+						hostname,
+					),
+				)
+				cp.SkipTask(1, "FTDC data", "node not on dcrcli host; no SSH user")
+				cp.SkipTask(2, "mongod logs", "node not on dcrcli host; no SSH user")
 			}
 		}
 
+		cp.FinishNode()
 	}
 
-	s.Stop()
+	cp.Finish()
 
-	fmt.Println("Data collection completed outputs directory location: ", outputdir.OutputPrefix)
+	ui.Header("Data collection complete")
+	ui.Ok("Outputs directory: " + outputdir.OutputPrefix)
 	dcrlog.Info("---End of Script Execution----")
 }
 

--- a/mongocredentials/mongocredentials.go
+++ b/mongocredentials/mongocredentials.go
@@ -15,12 +15,10 @@
 package mongocredentials
 
 import (
-	"bufio"
 	"crypto/rand"
 	"errors"
 	"fmt"
 	"math/big"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -30,6 +28,7 @@ import (
 
 	"dcrcli/dcrconfig"
 	"dcrcli/dcrlogger"
+	"dcrcli/termui"
 )
 
 type Mongocredentials struct {
@@ -90,33 +89,35 @@ func (mcred *Mongocredentials) validationOfMongoConnectionURIoptions() error {
 	return nil
 }
 
-func (s *Mongocredentials) askUserForMongoConnectionURIoptions() error {
-	reader := bufio.NewReader(os.Stdin)
-	fmt.Println(
-		"Enter MongoURI options for connecting to seed node without replicaSet option(in the format name1=value1&name2=value2): ",
+func (s *Mongocredentials) askUserForMongoConnectionURIoptions(ui *termui.UI) error {
+	ui.BeginStep("Extra connection options (optional)")
+	ui.Note(
+		"Only if your cluster needs extra MongoDB connection settings (e.g. tls=true).",
+		"Most users can leave this blank. Do not include replicaSet.",
+		"Format: name1=value1&name2=value2",
 	)
-
-	Mongourioptions, err := reader.ReadString('\n')
+	line, err := ui.AskInput("")
 	if err != nil {
 		return err
 	}
 
-	err = checkStringLessThan16MB(Mongourioptions)
+	err = checkStringLessThan16MB(line)
 	if err != nil {
 		return err
 	}
 
-	s.Mongourioptions = strings.TrimSuffix(Mongourioptions, "\n")
+	s.Mongourioptions = line
 	if s.Mongourioptions == "" {
+		ui.Ok("No extra URI options")
 		return nil
 	}
 
 	err = s.validationOfMongoConnectionURIoptions()
 	if err != nil {
-		// println(err.Error())
 		return err
 	}
 
+	ui.Ok("URI options set")
 	return nil
 }
 
@@ -131,12 +132,14 @@ func (s *Mongocredentials) SetMongoURI() error {
 	return nil
 }
 
-func (s *Mongocredentials) askUserForMongoConnectionUsername() error {
-	reader := bufio.NewReader(os.Stdin)
-	fmt.Println(
-		"Enter Admin Username(A database user with minimum backup, readAnyDatabase, clusterMonitor roles. Leave Blank for cluster without authentication): ",
+func (s *Mongocredentials) askUserForMongoConnectionUsername(ui *termui.UI) error {
+	ui.BeginStep("MongoDB username")
+	ui.Note(
+		"Database user for connecting to the cluster (not your laptop or SSH login).",
+		"Needs backup, readAnyDatabase, and clusterMonitor roles when auth is enabled.",
+		"Leave blank if the cluster has no authentication.",
 	)
-	username, err := reader.ReadString('\n')
+	username, err := ui.AskInput("")
 	if err != nil {
 		return err
 	}
@@ -146,39 +149,53 @@ func (s *Mongocredentials) askUserForMongoConnectionUsername() error {
 		return err
 	}
 
-	s.Username = strings.TrimSuffix(username, "\n")
+	s.Username = username
 	if s.Username == "" {
-		println("WARNING: Admin Username is empty assuming cluster without authentication")
+		ui.Warn("No MongoDB username; assuming cluster without authentication")
+	} else {
+		ui.Ok("MongoDB username set")
 	}
 
 	return nil
 }
 
-func (s *Mongocredentials) askUserForMongoConnectionPassword() error {
-	fmt.Println("Enter Admin Password(Leave blank for cluster without authentication): ")
-	bytePassword, err := term.ReadPassword(syscall.Stdin)
-	if err != nil {
-		return err
-	}
-
-	err = checkStringLessThan16MB(string(bytePassword))
-	if err != nil {
-		return err
-	}
-
-	s.Password = strings.TrimSuffix(string(bytePassword), "\n")
-
-	return nil
-}
-
-func (s *Mongocredentials) askUserForSeedMongodHostname() error {
-	reader := bufio.NewReader(os.Stdin)
-	fmt.Println("Due to privacy/security reasons the program does not scan all machine processes")
-	fmt.Println(
-		"Only the provided the seed mongod process is used to discover cluster nodes using mongo commands",
+func (s *Mongocredentials) askUserForMongoConnectionPassword(ui *termui.UI) error {
+	ui.BeginStep("MongoDB password")
+	ui.Note(
+		"Password for the MongoDB database user above (not your SSH password).",
+		"Leave blank if the cluster has no authentication.",
 	)
-	fmt.Println("Enter Hostname of Seed Mongod/Mongos: ")
-	seedmongodhost, err := reader.ReadString('\n')
+	bytePassword, err := ui.AskPassword("MongoDB password")
+	if err != nil {
+		return err
+	}
+
+	err = checkStringLessThan16MB(bytePassword)
+	if err != nil {
+		return err
+	}
+
+	s.Password = strings.TrimSuffix(bytePassword, "\n")
+	if s.Password == "" {
+		if s.Username == "" {
+			ui.Warn("No MongoDB password; assuming cluster without authentication")
+		} else {
+			ui.Warn("MongoDB password left empty")
+		}
+	} else {
+		ui.Ok("MongoDB password received")
+	}
+
+	return nil
+}
+
+func (s *Mongocredentials) askUserForSeedMongodHostname(ui *termui.UI) error {
+	ui.BeginStep("Seed node (cluster entry point)")
+	ui.Note(
+		"One reachable mongod/mongos (local or remote). dcrcli discovers other members via hello/getShardMap.",
+		"For sharded clusters, use a mongos when possible (e.g. localhost, rs0-mongo1.example.com).",
+	)
+	seedmongodhost, err := ui.AskInput("")
 	if err != nil {
 		return err
 	}
@@ -188,20 +205,22 @@ func (s *Mongocredentials) askUserForSeedMongodHostname() error {
 		return err
 	}
 
-	s.Seedmongodhost = strings.TrimSuffix(seedmongodhost, "\n")
+	s.Seedmongodhost = seedmongodhost
 	if s.Seedmongodhost == "" {
-		println("WARNING: Seed Mongod/Mongos hostname left empty assuming localhost")
+		ui.Warn("Hostname left empty; using localhost")
 		s.Dcrlog.Debug("mongod host not provided defaulting to localhost")
 		s.Seedmongodhost = "localhost"
+	} else {
+		ui.Ok("Seed host: " + s.Seedmongodhost)
 	}
 
 	return nil
 }
 
-func (s *Mongocredentials) askUserForClustername() error {
-	reader := bufio.NewReader(os.Stdin)
-	fmt.Println("Enter Cluster Name: ")
-	clustername, err := reader.ReadString('\n')
+func (s *Mongocredentials) askUserForClustername(ui *termui.UI) error {
+	ui.BeginStep("Cluster name")
+	ui.Note("Used as the output directory name. Leave blank to generate a unique name.")
+	clustername, err := ui.AskInput("")
 	if err != nil {
 		return err
 	}
@@ -216,11 +235,14 @@ func (s *Mongocredentials) askUserForClustername() error {
 		return err
 	}
 
-	s.Clustername = strings.TrimSuffix(clustername, "\n")
+	s.Clustername = clustername
 	if s.Clustername == "" {
-		println("WARNING: Clustername left empty generating unique name")
+		ui.Warn("Cluster name left empty; generating unique name")
 		s.Dcrlog.Debug("cluster name empty will generate unique random name")
 		s.generateUniqueName()
+		ui.Ok("Generated cluster name: " + s.Clustername)
+	} else {
+		ui.Ok("Cluster name: " + s.Clustername)
 	}
 
 	return nil
@@ -238,10 +260,13 @@ func (s *Mongocredentials) generateUniqueName() {
 	s.Dcrlog.Debug(fmt.Sprintf("generate unique name: %s", s.Clustername))
 }
 
-func (s *Mongocredentials) askUserForSeedMongoDport() error {
-	reader := bufio.NewReader(os.Stdin)
-	fmt.Println("Enter Port number of Seed Mongod/Mongos instance: ")
-	seedmongodport, err := reader.ReadString('\n')
+func (s *Mongocredentials) askUserForSeedMongoDport(ui *termui.UI) error {
+	ui.BeginStep("Seed port")
+	ui.Note(
+		"TCP port of the seed mongod/mongos listener.",
+		"Leave blank for default port 27017.",
+	)
+	seedmongodport, err := ui.AskInput("")
 	if err != nil {
 		return err
 	}
@@ -251,9 +276,9 @@ func (s *Mongocredentials) askUserForSeedMongoDport() error {
 		return err
 	}
 
-	s.Seedmongodport = strings.TrimSuffix(seedmongodport, "\n")
+	s.Seedmongodport = seedmongodport
 	if s.Seedmongodport == "" {
-		println("WARNING: Seed Mongod/Mongos port left empty assuming 27017")
+		ui.Warn("Port left empty; using default port 27017")
 		s.Dcrlog.Debug("mongod port not provided defaulting to 27017")
 		s.Seedmongodport = "27017"
 	}
@@ -263,40 +288,50 @@ func (s *Mongocredentials) askUserForSeedMongoDport() error {
 		return err
 	}
 
+	ui.Ok("Seed port: " + s.Seedmongodport)
 	return nil
 }
 
-func (s *Mongocredentials) Get() error {
+// Get collects MongoDB connection details through interactive prompts.
+func (s *Mongocredentials) Get(ui *termui.UI) error {
 	var err error
 
-	err = s.askUserForClustername()
+	// TSTOOLS-16661: future improvement to pass all connection fields via config and skip prompts.
+	ui.Header("MongoDB connection setup")
+	ui.Tip("Tip: use -config <file> to skip these prompts. See README: https://github.com/mongodb-labs/dcrcli#config-file-recommended")
+
+	err = s.askUserForClustername(ui)
 	if err != nil {
 		return err
 	}
 
-	err = s.askUserForSeedMongodHostname()
+	err = s.askUserForSeedMongodHostname(ui)
 	if err != nil {
 		return err
 	}
-	err = s.askUserForSeedMongoDport()
-	if err != nil {
-		return err
-	}
-
-	err = s.askUserForMongoConnectionUsername()
+	err = s.askUserForSeedMongoDport(ui)
 	if err != nil {
 		return err
 	}
 
-	err = s.askUserForMongoConnectionPassword()
+	err = s.askUserForMongoConnectionUsername(ui)
 	if err != nil {
 		return err
 	}
 
-	err = s.askUserForMongoConnectionURIoptions()
+	err = s.askUserForMongoConnectionPassword(ui)
 	if err != nil {
 		return err
 	}
+
+	err = s.askUserForMongoConnectionURIoptions(ui)
+	if err != nil {
+		return err
+	}
+
+	ui.Section("Connection ready")
+	ui.Ok(fmt.Sprintf("mongodb://%s:%s/admin", s.Seedmongodhost, s.Seedmongodport))
+	ui.Blank()
 
 	// set current host and port before setting Mongouri
 	s.Currentmongodhost = s.Seedmongodhost
@@ -308,7 +343,7 @@ func (s *Mongocredentials) Get() error {
 
 // GetFromConfig populates credentials from a config file instead of interactive prompts.
 // Any validation error names the offending config field so the user knows what to fix.
-func (s *Mongocredentials) GetFromConfig(c *dcrconfig.Config) error {
+func (s *Mongocredentials) GetFromConfig(ui *termui.UI, c *dcrconfig.Config) error {
 	s.Clustername = strings.TrimSpace(c.ClusterName)
 	if s.Clustername == "" {
 		s.generateUniqueName()
@@ -346,8 +381,9 @@ func (s *Mongocredentials) GetFromConfig(c *dcrconfig.Config) error {
 		if !term.IsTerminal(int(syscall.Stdin)) {
 			return fmt.Errorf("config: cannot prompt for MongoDB password (stdin is not a terminal)")
 		}
-		fmt.Println("Enter MongoDB Password: ")
-		bytePassword, err := term.ReadPassword(syscall.Stdin)
+		ui.BeginStep("MongoDB password")
+		ui.Note("Password for the MongoDB database user (not stored in the config file).")
+		bytePassword, err := ui.AskPassword("MongoDB password")
 		if err != nil {
 			return fmt.Errorf("config: failed to read password interactively: %w", err)
 		}
@@ -356,6 +392,7 @@ func (s *Mongocredentials) GetFromConfig(c *dcrconfig.Config) error {
 		if err := checkStringLessThan16MB(s.Password); err != nil {
 			return fmt.Errorf("config: password input: %w", err)
 		}
+		ui.Ok("Password received")
 	} else {
 		s.Dcrlog.Debug("no username set, assuming no-auth cluster")
 	}

--- a/termui/termui.go
+++ b/termui/termui.go
@@ -1,0 +1,601 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package termui provides a consistent interactive terminal experience for dcrcli.
+//
+// Prompts follow the common Go CLI pattern used by survey, promptui, and gum:
+// a short label on the same line as input (no decorative boxes). Libraries like
+// charmbracelet/huh offer richer TUI forms (arrow-key selects, themes) but add
+// weight and complexity; dcrcli keeps prompts lightweight for scripting and -config.
+package termui
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/fatih/color"
+	"golang.org/x/term"
+)
+
+const (
+	headerWidth      = 62
+	progressBarWidth = 32
+)
+
+// READMEPrerequisitesURL points to SSH and environment setup instructions.
+const READMEPrerequisitesURL = "https://github.com/mongodb-labs/dcrcli#prerequisites"
+
+// UI renders styled prompts and messages to a terminal.
+type UI struct {
+	in        io.Reader
+	out       io.Writer
+	reader    *bufio.Reader
+	step      int
+	stepTotal int
+	useColor  bool
+	taskAvg   [3]time.Duration
+	taskAvgCount [3]int
+}
+
+// New creates a UI bound to the given input and output streams.
+func New(in io.Reader, out io.Writer) *UI {
+	reader, ok := in.(*bufio.Reader)
+	if !ok {
+		reader = bufio.NewReader(in)
+	}
+	useColor := false
+	if f, ok := out.(*os.File); ok {
+		useColor = term.IsTerminal(int(f.Fd()))
+	}
+	return &UI{
+		in:       in,
+		out:      out,
+		reader:   reader,
+		useColor: useColor,
+	}
+}
+
+// NewDefault creates a UI using os.Stdin and os.Stdout.
+func NewDefault() *UI {
+	return New(os.Stdin, os.Stdout)
+}
+
+// SetStepTotal enables [n/total] labels on BeginStep calls.
+func (u *UI) SetStepTotal(total int) {
+	u.stepTotal = total
+}
+
+// EndStepSession clears numbered step labels so the next prompts start a new section.
+func (u *UI) EndStepSession() {
+	u.step = 0
+	u.stepTotal = 0
+}
+
+func (u *UI) paint(c *color.Color, s string) string {
+	if !u.useColor {
+		return s
+	}
+	return c.Sprint(s)
+}
+
+func (u *UI) println(s string) {
+	_, _ = fmt.Fprintln(u.out, s)
+}
+
+func (u *UI) print(s string) {
+	_, _ = fmt.Fprint(u.out, s)
+}
+
+func (u *UI) dim(s string) string {
+	return u.paint(color.New(color.FgHiBlack), s)
+}
+
+func (u *UI) promptPrefix() string {
+	return u.paint(color.New(color.FgGreen, color.Bold), "› ")
+}
+
+func (u *UI) readLine() (string, error) {
+	line, err := u.reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")), nil
+}
+
+// Header prints a top-level section banner.
+func (u *UI) Header(title string) {
+	line := strings.Repeat("═", headerWidth)
+	u.println("")
+	u.println(u.paint(color.New(color.FgCyan, color.Bold), line))
+	u.println(u.paint(color.New(color.FgCyan, color.Bold), fmt.Sprintf("  %s", title)))
+	u.println(u.paint(color.New(color.FgCyan, color.Bold), line))
+	u.println("")
+}
+
+// Tip prints secondary guidance in a dim style.
+func (u *UI) Tip(msg string) {
+	u.println(u.dim("  " + msg))
+	u.println("")
+}
+
+// BeginStep starts a numbered prompt step.
+func (u *UI) BeginStep(title string) {
+	u.step++
+	u.println("")
+	if u.stepTotal > 0 {
+		u.println(
+			u.paint(
+				color.New(color.FgHiCyan, color.Bold),
+				fmt.Sprintf("  [%d/%d] %s", u.step, u.stepTotal, title),
+			),
+		)
+		return
+	}
+	u.println(u.paint(color.New(color.FgHiCyan, color.Bold), "  "+title))
+}
+
+// Note prints helper text under a step.
+func (u *UI) Note(lines ...string) {
+	for _, line := range lines {
+		u.println(u.dim("  " + line))
+	}
+}
+
+// AskInput reads a line. label is shown on the same line as the cursor (survey-style).
+// Pass an empty label when BeginStep already names the field.
+func (u *UI) AskInput(label string) (string, error) {
+	u.print("  ")
+	u.print(u.promptPrefix())
+	if label != "" {
+		u.print(label)
+		if !strings.HasSuffix(label, ":") && !strings.HasSuffix(label, "?") {
+			u.print(":")
+		}
+		u.print(" ")
+	}
+	return u.readLine()
+}
+
+// AskPassword reads a hidden password on the same line as the prompt.
+func (u *UI) AskPassword(label string) (string, error) {
+	u.print("  ")
+	u.print(u.promptPrefix())
+	if label == "" {
+		label = "Password"
+	}
+	u.print(label + ": ")
+
+	stdinFd := int(syscall.Stdin)
+	if f, ok := u.in.(*os.File); ok {
+		stdinFd = int(f.Fd())
+	}
+	bytePassword, err := term.ReadPassword(stdinFd)
+	if err != nil {
+		return "", err
+	}
+	u.println("")
+	return string(bytePassword), nil
+}
+
+// Menu prints a numbered list of options.
+func (u *UI) Menu(items []string) {
+	for i, item := range items {
+		u.println(fmt.Sprintf("    %d) %s", i+1, item))
+	}
+}
+
+// AskChoice reads a menu selection on the same line as the prompt.
+func (u *UI) AskChoice(hint string) (string, error) {
+	if hint == "" {
+		hint = "Choice [1]"
+	}
+	u.print("  ")
+	u.print(u.promptPrefix())
+	u.print(hint + ": ")
+	return u.readLine()
+}
+
+// AskYesNo prompts for confirmation on the same line as the prompt.
+func (u *UI) AskYesNo(hint string, defaultNo bool) (bool, error) {
+	defaultLabel := "y/N"
+	if !defaultNo {
+		defaultLabel = "Y/n"
+	}
+	prompt := hint
+	if prompt == "" {
+		prompt = "Continue"
+	}
+	u.print("  ")
+	u.print(u.promptPrefix())
+	u.print(fmt.Sprintf("%s [%s]: ", prompt, defaultLabel))
+
+	line, err := u.readLine()
+	if err != nil {
+		return false, err
+	}
+
+	answer := strings.ToLower(line)
+	switch answer {
+	case "":
+		return !defaultNo, nil
+	case "y", "yes":
+		return true, nil
+	case "n", "no":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid answer %q: enter y/yes or n/no", answer)
+	}
+}
+
+// Warn prints a warning message.
+func (u *UI) Warn(msg string) {
+	u.println(u.paint(color.New(color.FgYellow), "  ! "+msg))
+}
+
+// Ok prints a success message.
+func (u *UI) Ok(msg string) {
+	u.println(u.paint(color.New(color.FgGreen), "  ✓ "+msg))
+}
+
+// Section prints a sub-heading between flows.
+func (u *UI) Section(title string) {
+	u.println("")
+	u.println(u.paint(color.New(color.FgHiCyan, color.Bold), "  "+title))
+}
+
+// Info prints a neutral informational line.
+func (u *UI) Info(msg string) {
+	u.println("  " + msg)
+}
+
+// KeyValue prints an aligned label/value pair.
+func (u *UI) KeyValue(key, value string) {
+	u.println(fmt.Sprintf("  %-14s %s", key+":", value))
+}
+
+// ErrorBanner prints a prominent error block.
+func (u *UI) ErrorBanner(title string, lines ...string) {
+	u.println("")
+	line := strings.Repeat("═", headerWidth)
+	u.println(u.paint(color.New(color.FgRed, color.Bold), line))
+	u.println(u.paint(color.New(color.FgRed, color.Bold), fmt.Sprintf("  %s", title)))
+	u.println(u.paint(color.New(color.FgRed, color.Bold), line))
+	u.println("")
+	for _, msg := range lines {
+		u.println("  " + msg)
+	}
+	u.println("")
+}
+
+// Blank prints a single empty line.
+func (u *UI) Blank() {
+	u.println("")
+}
+
+func (u *UI) progressBar(filled, width int) string {
+	if filled < 0 {
+		filled = 0
+	}
+	if filled > width {
+		filled = width
+	}
+	return u.paint(color.New(color.FgGreen), strings.Repeat("█", filled)) +
+		u.dim(strings.Repeat("░", width-filled))
+}
+
+// CollectionHost identifies a node shown in the collection progress display.
+type CollectionHost struct {
+	Hostname string
+	Port     int
+}
+
+type nodeState int
+
+const (
+	nodePending nodeState = iota
+	nodeActive
+	nodeDone
+	nodeFailed
+)
+
+type collectionNodeStatus struct {
+	host  CollectionHost
+	state nodeState
+}
+
+// CollectionStart prints the data-collection header and a single live progress bar for the full run.
+func (u *UI) CollectionStart(hosts []CollectionHost, tasksPerNode int) *CollectionProgress {
+	nodeTotal := len(hosts)
+	if nodeTotal < 1 {
+		nodeTotal = 1
+	}
+	if tasksPerNode < 1 {
+		tasksPerNode = 1
+	}
+	nodes := make([]collectionNodeStatus, len(hosts))
+	for i, h := range hosts {
+		nodes[i] = collectionNodeStatus{host: h, state: nodePending}
+	}
+	u.Header("Data collection")
+	cp := &CollectionProgress{
+		ui:         u,
+		nodes:      nodes,
+		totalTasks: nodeTotal * tasksPerNode,
+	}
+	cp.writeProgress()
+	return cp
+}
+
+// CollectionProgress tracks one live progress bar across all nodes and tasks.
+type CollectionProgress struct {
+	mu             sync.Mutex
+	ui             *UI
+	nodes          []collectionNodeStatus
+	totalTasks     int
+	tasksDone      int
+	taskStart      time.Time
+	currentTaskIdx int
+	currentIdx     int
+	activeSpinner  bool
+	nodeFailed     bool
+	initialized    bool
+}
+
+func (u *UI) defaultTaskEstimate(taskIdx int) time.Duration {
+	if taskIdx >= 0 && taskIdx < len(u.taskAvg) && u.taskAvg[taskIdx] > 0 {
+		return u.taskAvg[taskIdx]
+	}
+	switch taskIdx {
+	case 0:
+		return 800 * time.Millisecond
+	case 1:
+		return 1500 * time.Millisecond
+	default:
+		return 1200 * time.Millisecond
+	}
+}
+
+func (u *UI) recordTaskDuration(taskIdx int, d time.Duration) {
+	if taskIdx < 0 || taskIdx >= len(u.taskAvg) {
+		return
+	}
+	n := u.taskAvgCount[taskIdx]
+	if n == 0 {
+		u.taskAvg[taskIdx] = d
+	} else {
+		u.taskAvg[taskIdx] = (u.taskAvg[taskIdx]*time.Duration(n) + d) / time.Duration(n+1)
+	}
+	u.taskAvgCount[taskIdx]++
+}
+
+func (cp *CollectionProgress) fraction() float64 {
+	if cp.totalTasks <= 0 {
+		return 1
+	}
+	base := float64(cp.tasksDone) / float64(cp.totalTasks)
+	if !cp.activeSpinner {
+		return base
+	}
+	est := cp.ui.defaultTaskEstimate(cp.currentTaskIdx)
+	if est <= 0 {
+		est = time.Second
+	}
+	partial := float64(time.Since(cp.taskStart)) / float64(est)
+	if partial > 0.95 {
+		partial = 0.95
+	}
+	f := base + partial/float64(cp.totalTasks)
+	if f > 1 {
+		f = 1
+	}
+	return f
+}
+
+func (cp *CollectionProgress) barLine() string {
+	pct := int(cp.fraction() * 100)
+	if pct > 100 {
+		pct = 100
+	}
+	filled := int(cp.fraction() * float64(progressBarWidth))
+	if filled > progressBarWidth {
+		filled = progressBarWidth
+	}
+	return fmt.Sprintf("  %s  %3d%%", cp.ui.progressBar(filled, progressBarWidth), pct)
+}
+
+func (cp *CollectionProgress) nodeLine(i int) string {
+	n := cp.nodes[i]
+	switch n.state {
+	case nodeDone:
+		return cp.ui.paint(
+			color.New(color.FgGreen),
+			fmt.Sprintf("  ✓ %s:%d", n.host.Hostname, n.host.Port),
+		)
+	case nodeFailed:
+		return cp.ui.paint(
+			color.New(color.FgYellow),
+			fmt.Sprintf("  ! %s:%d", n.host.Hostname, n.host.Port),
+		)
+	case nodeActive:
+		return cp.ui.paint(
+			color.New(color.FgHiCyan),
+			fmt.Sprintf("  › %s:%d", n.host.Hostname, n.host.Port),
+		)
+	default:
+		return cp.ui.dim(fmt.Sprintf("  · %s:%d", n.host.Hostname, n.host.Port))
+	}
+}
+
+func (cp *CollectionProgress) allLines() []string {
+	lines := make([]string, 0, 1+len(cp.nodes))
+	lines = append(lines, cp.barLine())
+	for i := range cp.nodes {
+		lines = append(lines, cp.nodeLine(i))
+	}
+	return lines
+}
+
+func (cp *CollectionProgress) writeProgress() {
+	if !cp.ui.isTTY() {
+		return
+	}
+
+	cp.mu.Lock()
+	lines := cp.allLines()
+	cp.mu.Unlock()
+
+	if len(lines) == 0 {
+		return
+	}
+
+	if !cp.initialized {
+		for i, line := range lines {
+			if i < len(lines)-1 {
+				cp.ui.println(line)
+			} else {
+				cp.ui.print(line)
+			}
+		}
+		cp.initialized = true
+		return
+	}
+
+	fmt.Fprintf(cp.ui.out, "\033[%dA", len(lines)-1)
+	for i, line := range lines {
+		if i > 0 {
+			fmt.Fprint(cp.ui.out, "\n")
+		}
+		fmt.Fprintf(cp.ui.out, "\r\033[K%s", line)
+	}
+}
+
+// BeginNode marks which node is currently being collected.
+func (cp *CollectionProgress) BeginNode(idx int) {
+	cp.mu.Lock()
+	cp.currentIdx = idx
+	cp.nodeFailed = false
+	if idx >= 0 && idx < len(cp.nodes) {
+		cp.nodes[idx].state = nodeActive
+	}
+	cp.mu.Unlock()
+	cp.writeProgress()
+}
+
+// FinishNode marks the active node as done or failed.
+func (cp *CollectionProgress) FinishNode() {
+	cp.mu.Lock()
+	if cp.currentIdx >= 0 && cp.currentIdx < len(cp.nodes) {
+		if cp.nodeFailed {
+			cp.nodes[cp.currentIdx].state = nodeFailed
+		} else {
+			cp.nodes[cp.currentIdx].state = nodeDone
+		}
+	}
+	cp.mu.Unlock()
+	cp.writeProgress()
+}
+
+// RunTask runs a collection step and updates the global progress bar.
+func (cp *CollectionProgress) RunTask(taskIdx int, _ string, fn func() error) error {
+	cp.currentTaskIdx = taskIdx
+	cp.taskStart = time.Now()
+	cp.activeSpinner = true
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	if cp.ui.isTTY() {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ticker := time.NewTicker(100 * time.Millisecond)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-stop:
+					return
+				case <-ticker.C:
+					cp.writeProgress()
+				}
+			}
+		}()
+	}
+
+	err := fn()
+	close(stop)
+	wg.Wait()
+	cp.activeSpinner = false
+
+	if err != nil {
+		cp.mu.Lock()
+		cp.nodeFailed = true
+		cp.mu.Unlock()
+	}
+
+	cp.ui.recordTaskDuration(taskIdx, time.Since(cp.taskStart))
+	cp.tasksDone++
+	cp.writeProgress()
+	return err
+}
+
+// SkipTask records a skipped step and advances the global progress bar.
+func (cp *CollectionProgress) SkipTask(taskIdx int, _, _ string) {
+	_ = taskIdx
+	cp.tasksDone++
+	cp.writeProgress()
+}
+
+// Finish completes the progress bar and moves to the next output line.
+func (cp *CollectionProgress) Finish() {
+	cp.mu.Lock()
+	cp.activeSpinner = false
+	cp.tasksDone = cp.totalTasks
+	cp.mu.Unlock()
+
+	if cp.ui.isTTY() {
+		cp.writeProgress()
+		cp.ui.println("")
+		return
+	}
+	cp.ui.println(cp.barLine())
+}
+
+func (u *UI) isTTY() bool {
+	if f, ok := u.out.(*os.File); ok {
+		return term.IsTerminal(int(f.Fd()))
+	}
+	return false
+}
+
+func (u *UI) clearLine() {
+	if u.isTTY() {
+		_, _ = fmt.Fprint(u.out, "\r\033[K")
+	}
+}
+
+// CollectionTaskSkipped is a no-op; collection progress is shown only via CollectionProgress.
+func (u *UI) CollectionTaskSkipped(_, _ int, _, _ string) {}
+
+// SSHAuthNotice tells the user to enter an SSH password when rsync prompts for it.
+func SSHAuthNotice() {
+	ui := NewDefault()
+	ui.Section("SSH authentication")
+	ui.Note("Enter your SSH password when rsync prompts for it.")
+}

--- a/termui/termui.go
+++ b/termui/termui.go
@@ -25,10 +25,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
+	"unicode/utf8"
 
 	"github.com/fatih/color"
 	"golang.org/x/term"
@@ -37,20 +39,29 @@ import (
 const (
 	headerWidth      = 62
 	progressBarWidth = 32
+	// progressCompactNodeThreshold switches to bar + active node + counter (not full node list).
+	progressCompactNodeThreshold = 8
+	collectionTasksPerNode       = 3
 )
+
+var collectionTaskLabels = [collectionTasksPerNode]string{"getMongoData", "FTDC", "logs"}
+
+// ansiEscape matches SGR/CSI sequences so progress lines can be width-limited
+// without counting color codes toward the terminal column count.
+var ansiEscape = regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
 
 // READMEPrerequisitesURL points to SSH and environment setup instructions.
 const READMEPrerequisitesURL = "https://github.com/mongodb-labs/dcrcli#prerequisites"
 
 // UI renders styled prompts and messages to a terminal.
 type UI struct {
-	in        io.Reader
-	out       io.Writer
-	reader    *bufio.Reader
-	step      int
-	stepTotal int
-	useColor  bool
-	taskAvg   [3]time.Duration
+	in           io.Reader
+	out          io.Writer
+	reader       *bufio.Reader
+	step         int
+	stepTotal    int
+	useColor     bool
+	taskAvg      [3]time.Duration
 	taskAvgCount [3]int
 }
 
@@ -321,12 +332,28 @@ const (
 	nodePending nodeState = iota
 	nodeActive
 	nodeDone
+	nodePartial
 	nodeFailed
 )
+
+type taskOutcome int
+
+const (
+	taskPending taskOutcome = iota
+	taskOK
+	taskFailed
+	taskSkipped
+)
+
+type taskStatus struct {
+	outcome taskOutcome
+	note    string
+}
 
 type collectionNodeStatus struct {
 	host  CollectionHost
 	state nodeState
+	tasks [collectionTasksPerNode]taskStatus
 }
 
 // CollectionStart prints the data-collection header and a live progress view for the full run.
@@ -348,35 +375,34 @@ func (u *UI) CollectionStart(hosts []CollectionHost, tasksPerNode int) *Collecti
 		display = u.out
 	}
 	cp := &CollectionProgress{
-		ui:           u,
-		display:      display,
-		nodes:        nodes,
-		totalTasks:   nodeTotal * tasksPerNode,
-		useAltScreen: writerTTY(display),
+		ui:         u,
+		display:    display,
+		nodes:      nodes,
+		totalTasks: nodeTotal * tasksPerNode,
+		compact:    nodeTotal > progressCompactNodeThreshold,
 	}
 	activeCollectionProgress = cp
-	cp.enterAltScreen()
 	cp.writeProgress()
 	return cp
 }
 
 // CollectionProgress tracks one live progress bar across all nodes and tasks.
 type CollectionProgress struct {
-	mu             sync.Mutex
-	ui             *UI
-	display        io.Writer
-	nodes          []collectionNodeStatus
-	totalTasks     int
-	tasksDone      int
-	taskStart      time.Time
-	currentTaskIdx int
-	currentIdx     int
-	activeSpinner  bool
-	nodeFailed     bool
-	initialized    bool
-	linesOnScreen  int
-	useAltScreen bool
-	onAltScreen  bool
+	mu              sync.Mutex
+	ui              *UI
+	display         io.Writer
+	nodes           []collectionNodeStatus
+	totalTasks      int
+	tasksDone       int
+	taskStart       time.Time
+	currentTaskIdx  int
+	currentIdx      int
+	activeSpinner   bool
+	compact         bool
+	initialized     bool
+	compactLineOpen bool // cursor is on the progress bar row
+	onHintLine      bool // cursor is on the reusable SSH hint row under the bar
+	linesOnScreen   int
 }
 
 var activeCollectionProgress *CollectionProgress
@@ -415,23 +441,8 @@ func (cp *CollectionProgress) fraction() float64 {
 	if cp.totalTasks <= 0 {
 		return 1
 	}
-	base := float64(cp.tasksDone) / float64(cp.totalTasks)
-	if !cp.activeSpinner {
-		return base
-	}
-	est := cp.ui.defaultTaskEstimate(cp.currentTaskIdx)
-	if est <= 0 {
-		est = time.Second
-	}
-	partial := float64(time.Since(cp.taskStart)) / float64(est)
-	if partial > 0.95 {
-		partial = 0.95
-	}
-	f := base + partial/float64(cp.totalTasks)
-	if f > 1 {
-		f = 1
-	}
-	return f
+	// Keep progress discrete (completed steps only) to avoid noisy percentage creep.
+	return float64(cp.tasksDone) / float64(cp.totalTasks)
 }
 
 func (cp *CollectionProgress) barLine() string {
@@ -464,16 +475,139 @@ func (cp *CollectionProgress) nodeLine(i int) string {
 			color.New(color.FgHiCyan),
 			fmt.Sprintf("  › %s:%d", n.host.Hostname, n.host.Port),
 		)
+	case nodePartial:
+		return cp.ui.paint(
+			color.New(color.FgHiYellow),
+			fmt.Sprintf("  ~ %s:%d", n.host.Hostname, n.host.Port),
+		)
 	default:
 		return cp.ui.dim(fmt.Sprintf("  · %s:%d", n.host.Hostname, n.host.Port))
 	}
 }
 
-func (cp *CollectionProgress) allLines() []string {
-	lines := make([]string, 0, 1+len(cp.nodes))
-	lines = append(lines, cp.barLine())
+func (cp *CollectionProgress) nodeCounts() (done, partial, failed, total int) {
+	total = len(cp.nodes)
+	for _, n := range cp.nodes {
+		switch n.state {
+		case nodeDone:
+			done++
+		case nodePartial:
+			partial++
+		case nodeFailed:
+			failed++
+		}
+	}
+	return done, partial, failed, total
+}
+
+func (cp *CollectionProgress) deriveNodeState(i int) nodeState {
+	if i < 0 || i >= len(cp.nodes) {
+		return nodePending
+	}
+	hasFail, hasSkip, hasOK := false, false, false
+	for _, t := range cp.nodes[i].tasks {
+		switch t.outcome {
+		case taskFailed:
+			hasFail = true
+		case taskSkipped:
+			hasSkip = true
+		case taskOK:
+			hasOK = true
+		}
+	}
+	if hasFail {
+		return nodeFailed
+	}
+	if hasSkip && hasOK {
+		return nodePartial
+	}
+	return nodeDone
+}
+
+func (cp *CollectionProgress) taskSummaryPart(taskIdx int, t taskStatus) string {
+	label := collectionTaskLabels[taskIdx]
+	switch t.outcome {
+	case taskOK:
+		return cp.ui.paint(color.New(color.FgGreen), "✓") + " " + label
+	case taskFailed:
+		return cp.ui.paint(color.New(color.FgYellow), "!") + " " + label
+	case taskSkipped:
+		return cp.ui.dim("− " + label)
+	default:
+		return cp.ui.dim("· " + label)
+	}
+}
+
+func (cp *CollectionProgress) nodeResultLine(i int) string {
+	if i < 0 || i >= len(cp.nodes) {
+		return ""
+	}
+	n := cp.nodes[i]
+	host := fmt.Sprintf("%s:%d", n.host.Hostname, n.host.Port)
+
+	var prefix string
+	switch n.state {
+	case nodeFailed:
+		prefix = cp.ui.paint(color.New(color.FgYellow), "  ! "+host)
+	case nodePartial:
+		prefix = cp.ui.paint(color.New(color.FgHiYellow), "  ~ "+host)
+	default:
+		prefix = cp.ui.paint(color.New(color.FgGreen), "  ✓ "+host)
+	}
+
+	parts := make([]string, collectionTasksPerNode)
+	for t := 0; t < collectionTasksPerNode; t++ {
+		parts[t] = cp.taskSummaryPart(t, n.tasks[t])
+	}
+	return prefix + "  " + strings.Join(parts, "  ")
+}
+
+func (cp *CollectionProgress) collectionTotalsLine() string {
+	done, partial, failed, total := cp.nodeCounts()
+	if total == 0 {
+		return ""
+	}
+	parts := []string{fmt.Sprintf("%d/%d nodes complete", done+partial+failed, total)}
+	if partial > 0 {
+		parts = append(parts, fmt.Sprintf("%d partial", partial))
+	}
+	if failed > 0 {
+		parts = append(parts, fmt.Sprintf("%d failed", failed))
+	}
+	return cp.ui.dim("  " + strings.Join(parts, " · "))
+}
+
+func (cp *CollectionProgress) progressLines() []string {
+	return []string{cp.compactStatusLine()}
+}
+
+func (cp *CollectionProgress) compactStatusLine() string {
+	line := cp.barLine()
 	for i := range cp.nodes {
-		lines = append(lines, cp.nodeLine(i))
+		if cp.nodes[i].state == nodeActive {
+			n := cp.nodes[i]
+			line += cp.ui.paint(
+				color.New(color.FgHiCyan),
+				fmt.Sprintf("  › %s:%d", n.host.Hostname, n.host.Port),
+			)
+			break
+		}
+	}
+	done, partial, failed, total := cp.nodeCounts()
+	if total > 0 {
+		completed := done + partial + failed
+		line += cp.ui.dim(fmt.Sprintf("  %d/%d nodes", completed, total))
+	}
+	return line
+}
+
+// summaryLines is the final on-screen progress block after collection.
+func (cp *CollectionProgress) summaryLines() []string {
+	lines := []string{cp.barLine()}
+	if !cp.compact {
+		for i := range cp.nodes {
+			lines = append(lines, cp.nodeResultLine(i))
+		}
 	}
 	return lines
 }
@@ -483,25 +617,92 @@ func writerTTY(w io.Writer) bool {
 	return ok && term.IsTerminal(int(f.Fd()))
 }
 
-func (cp *CollectionProgress) enterAltScreen() {
-	if !cp.useAltScreen || cp.onAltScreen {
-		return
-	}
-	fmt.Fprint(cp.display, "\033[?1049h\033[H\033[2J")
-	cp.onAltScreen = true
-	cp.initialized = false
-	cp.linesOnScreen = 0
+func stripANSI(s string) string {
+	return ansiEscape.ReplaceAllString(s, "")
 }
 
-func (cp *CollectionProgress) leaveAltScreen(hint string) {
-	if cp.onAltScreen {
-		fmt.Fprint(cp.display, "\033[?1049l")
-		cp.onAltScreen = false
-		cp.initialized = false
-		cp.linesOnScreen = 0
+func visibleLen(s string) int {
+	return utf8.RuneCountInString(stripANSI(s))
+}
+
+func (cp *CollectionProgress) termSize() (w, h int) {
+	w, h = 80, 24
+	f, ok := cp.display.(*os.File)
+	if !ok {
+		return w, h
 	}
-	if hint != "" {
-		fmt.Fprintln(cp.display, cp.ui.dim("  "+hint))
+	tw, th, err := term.GetSize(int(f.Fd()))
+	if err != nil {
+		return w, h
+	}
+	if tw >= 20 {
+		w = tw
+	}
+	if th >= 3 {
+		h = th
+	}
+	return w, h
+}
+
+func (cp *CollectionProgress) termWidth() int {
+	w, _ := cp.termSize()
+	return w
+}
+
+// fitLine truncates s to at most width visible columns so the terminal will
+// not wrap the live progress line (wrapping would make \r start a new row).
+func fitLine(s string, width int) string {
+	if width < 1 {
+		return ""
+	}
+	if visibleLen(s) <= width {
+		return s
+	}
+	plain := []rune(stripANSI(s))
+	if width == 1 {
+		return string(plain[:1])
+	}
+	return string(plain[:width-1]) + "…"
+}
+
+// writeProgressLine redraws the bar on a single row. A second row is reserved
+// for the current SSH hint and is overwritten, so large clusters do not log
+// one SSH line per node.
+func (cp *CollectionProgress) writeProgressLine(line string) {
+	line = fitLine(line, cp.termWidth()-1)
+	if !cp.initialized {
+		fmt.Fprintf(cp.display, "\r\033[2K%s\n\033[2K\033[1A", line)
+		cp.initialized = true
+	} else {
+		if cp.onHintLine {
+			fmt.Fprint(cp.display, "\033[1A")
+			cp.onHintLine = false
+		}
+		fmt.Fprintf(cp.display, "\r\033[2K%s", line)
+	}
+	cp.compactLineOpen = true
+	cp.linesOnScreen = 1
+}
+
+func (cp *CollectionProgress) printNodeReport() {
+	cp.mu.Lock()
+	n := len(cp.nodes)
+	cp.mu.Unlock()
+	if n == 0 {
+		return
+	}
+
+	fmt.Fprintln(cp.display, cp.ui.dim("  Node results:"))
+	for i := 0; i < n; i++ {
+		cp.mu.Lock()
+		line := cp.nodeResultLine(i)
+		cp.mu.Unlock()
+		if line != "" {
+			fmt.Fprintln(cp.display, line)
+		}
+	}
+	if totals := cp.collectionTotalsLine(); totals != "" {
+		fmt.Fprintln(cp.display, totals)
 	}
 }
 
@@ -509,52 +710,16 @@ func (cp *CollectionProgress) writeProgress() {
 	if !writerTTY(cp.display) {
 		return
 	}
-	if cp.useAltScreen && !cp.onAltScreen {
-		return
-	}
-
 	cp.mu.Lock()
-	lines := cp.allLines()
-	prev := cp.linesOnScreen
+	line := cp.compactStatusLine()
 	cp.mu.Unlock()
-
-	if len(lines) == 0 {
-		return
-	}
-
-	if !cp.initialized {
-		for i, line := range lines {
-			if i < len(lines)-1 {
-				fmt.Fprintln(cp.display, line)
-			} else {
-				fmt.Fprint(cp.display, line)
-			}
-		}
-		cp.initialized = true
-		cp.linesOnScreen = len(lines)
-		return
-	}
-
-	if prev > 0 {
-		fmt.Fprintf(cp.display, "\033[%dA", prev)
-	}
-	for i, line := range lines {
-		if i > 0 {
-			fmt.Fprint(cp.display, "\n")
-		}
-		fmt.Fprintf(cp.display, "\r\033[K%s", line)
-	}
-	for i := len(lines); i < prev; i++ {
-		fmt.Fprint(cp.display, "\n\033[K")
-	}
-	cp.linesOnScreen = len(lines)
+	cp.writeProgressLine(line)
 }
 
 // BeginNode marks which node is currently being collected.
 func (cp *CollectionProgress) BeginNode(idx int) {
 	cp.mu.Lock()
 	cp.currentIdx = idx
-	cp.nodeFailed = false
 	if idx >= 0 && idx < len(cp.nodes) {
 		cp.nodes[idx].state = nodeActive
 	}
@@ -566,11 +731,7 @@ func (cp *CollectionProgress) BeginNode(idx int) {
 func (cp *CollectionProgress) FinishNode() {
 	cp.mu.Lock()
 	if cp.currentIdx >= 0 && cp.currentIdx < len(cp.nodes) {
-		if cp.nodeFailed {
-			cp.nodes[cp.currentIdx].state = nodeFailed
-		} else {
-			cp.nodes[cp.currentIdx].state = nodeDone
-		}
+		cp.nodes[cp.currentIdx].state = cp.deriveNodeState(cp.currentIdx)
 	}
 	cp.mu.Unlock()
 	cp.writeProgress()
@@ -609,8 +770,24 @@ func sshHandoffMessage(ssh *SSHTarget) string {
 	)
 }
 
-func (cp *CollectionProgress) leaveForSubprocess(ssh *SSHTarget) {
-	cp.leaveAltScreen(sshHandoffMessage(ssh))
+func (cp *CollectionProgress) handoffForSubprocess(ssh *SSHTarget) {
+	msg := fitLine(cp.ui.dim("  "+sshHandoffMessage(ssh)), cp.termWidth()-1)
+	if cp.onHintLine {
+		fmt.Fprintf(cp.display, "\r\033[2K%s", msg)
+		return
+	}
+	fmt.Fprintf(cp.display, "\n\r\033[2K%s", msg)
+	cp.onHintLine = true
+	cp.compactLineOpen = false
+}
+
+func (cp *CollectionProgress) reconcileAfterSubprocess() {
+	if cp.onHintLine {
+		fmt.Fprint(cp.display, "\r\033[2K\033[1A")
+		cp.onHintLine = false
+		cp.compactLineOpen = true
+	}
+	cp.writeProgress()
 }
 
 // RunTask runs a collection step and updates the global progress bar.
@@ -619,50 +796,29 @@ func (cp *CollectionProgress) RunTask(taskIdx int, ssh *SSHTarget, fn func() err
 	cp.currentTaskIdx = taskIdx
 	cp.taskStart = time.Now()
 	cp.activeSpinner = true
-
-	stop := make(chan struct{})
-	var wg sync.WaitGroup
-
-	if writerTTY(cp.display) && (!cp.useAltScreen || cp.onAltScreen) {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			ticker := time.NewTicker(100 * time.Millisecond)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-stop:
-					return
-				case <-ticker.C:
-					cp.writeProgress()
-				}
-			}
-		}()
-	}
-
 	cp.writeProgress()
 
 	if ssh != nil {
-		close(stop)
-		wg.Wait()
-		cp.leaveForSubprocess(ssh)
+		cp.handoffForSubprocess(ssh)
 	}
 
 	err := fn()
 
 	if ssh != nil {
-		cp.enterAltScreen()
-	} else {
-		close(stop)
-		wg.Wait()
+		cp.reconcileAfterSubprocess()
 	}
 
 	cp.activeSpinner = false
-	if err != nil {
-		cp.mu.Lock()
-		cp.nodeFailed = true
-		cp.mu.Unlock()
+
+	cp.mu.Lock()
+	if cp.currentIdx >= 0 && cp.currentIdx < len(cp.nodes) && taskIdx >= 0 && taskIdx < collectionTasksPerNode {
+		ts := taskStatus{outcome: taskOK}
+		if err != nil {
+			ts.outcome = taskFailed
+		}
+		cp.nodes[cp.currentIdx].tasks[taskIdx] = ts
 	}
+	cp.mu.Unlock()
 
 	cp.ui.recordTaskDuration(taskIdx, time.Since(cp.taskStart))
 	cp.tasksDone++
@@ -671,33 +827,38 @@ func (cp *CollectionProgress) RunTask(taskIdx int, ssh *SSHTarget, fn func() err
 }
 
 // SkipTask records a skipped step and advances the global progress bar.
-func (cp *CollectionProgress) SkipTask(taskIdx int, _, _ string) {
-	_ = taskIdx
+func (cp *CollectionProgress) SkipTask(taskIdx int, _, reason string) {
+	cp.mu.Lock()
+	if cp.currentIdx >= 0 && cp.currentIdx < len(cp.nodes) && taskIdx >= 0 && taskIdx < collectionTasksPerNode {
+		cp.nodes[cp.currentIdx].tasks[taskIdx] = taskStatus{outcome: taskSkipped, note: reason}
+	}
 	cp.tasksDone++
+	cp.mu.Unlock()
 	cp.writeProgress()
 }
 
-// Finish completes the progress bar and prints the final node list on the main screen.
+// Finish completes the progress bar and leaves the final summary on the same screen.
 func (cp *CollectionProgress) Finish() {
 	cp.mu.Lock()
 	cp.activeSpinner = false
 	cp.tasksDone = cp.totalTasks
-	summary := cp.allLines()
+	bar := cp.barLine()
 	cp.mu.Unlock()
 
 	activeCollectionProgress = nil
-	cp.leaveAltScreen("")
 
 	if !writerTTY(cp.display) {
-		if len(summary) > 0 {
-			fmt.Fprintln(cp.display, summary[0])
-		}
+		fmt.Fprintln(cp.display, bar)
 		return
 	}
 
-	for _, line := range summary {
-		fmt.Fprintln(cp.display, line)
+	if cp.onHintLine {
+		fmt.Fprint(cp.display, "\r\033[2K\033[1A")
+		cp.onHintLine = false
 	}
+	fmt.Fprintf(cp.display, "\r\033[2K%s\n\033[2K\n", fitLine(bar, cp.termWidth()-1))
+	cp.compactLineOpen = false
+	cp.printNodeReport()
 	fmt.Fprintln(cp.display)
 }
 

--- a/termui/termui.go
+++ b/termui/termui.go
@@ -306,6 +306,15 @@ type CollectionHost struct {
 	Port     int
 }
 
+// SSHTarget identifies the host rsync/ssh connects to when leaving the progress view.
+type SSHTarget struct {
+	User      string
+	Host      string // SSH/rsync hostname
+	Purpose   string // e.g. "FTDC data", "mongod logs"
+	MongoHost string // MongoDB node being collected (for display)
+	MongoPort int
+}
+
 type nodeState int
 
 const (
@@ -320,7 +329,7 @@ type collectionNodeStatus struct {
 	state nodeState
 }
 
-// CollectionStart prints the data-collection header and a single live progress bar for the full run.
+// CollectionStart prints the data-collection header and a live progress view for the full run.
 func (u *UI) CollectionStart(hosts []CollectionHost, tasksPerNode int) *CollectionProgress {
 	nodeTotal := len(hosts)
 	if nodeTotal < 1 {
@@ -334,11 +343,19 @@ func (u *UI) CollectionStart(hosts []CollectionHost, tasksPerNode int) *Collecti
 		nodes[i] = collectionNodeStatus{host: h, state: nodePending}
 	}
 	u.Header("Data collection")
-	cp := &CollectionProgress{
-		ui:         u,
-		nodes:      nodes,
-		totalTasks: nodeTotal * tasksPerNode,
+	var display io.Writer = os.Stdout
+	if !writerTTY(display) {
+		display = u.out
 	}
+	cp := &CollectionProgress{
+		ui:           u,
+		display:      display,
+		nodes:        nodes,
+		totalTasks:   nodeTotal * tasksPerNode,
+		useAltScreen: writerTTY(display),
+	}
+	activeCollectionProgress = cp
+	cp.enterAltScreen()
 	cp.writeProgress()
 	return cp
 }
@@ -347,6 +364,7 @@ func (u *UI) CollectionStart(hosts []CollectionHost, tasksPerNode int) *Collecti
 type CollectionProgress struct {
 	mu             sync.Mutex
 	ui             *UI
+	display        io.Writer
 	nodes          []collectionNodeStatus
 	totalTasks     int
 	tasksDone      int
@@ -356,7 +374,15 @@ type CollectionProgress struct {
 	activeSpinner  bool
 	nodeFailed     bool
 	initialized    bool
+	linesOnScreen  int
+	useAltScreen bool
+	onAltScreen  bool
 }
+
+var activeCollectionProgress *CollectionProgress
+
+// LeaveForSubprocess is a no-op; RunTask leaves the progress view when usesTerminal is true.
+func LeaveForSubprocess(string) {}
 
 func (u *UI) defaultTaskEstimate(taskIdx int) time.Duration {
 	if taskIdx >= 0 && taskIdx < len(u.taskAvg) && u.taskAvg[taskIdx] > 0 {
@@ -452,13 +478,44 @@ func (cp *CollectionProgress) allLines() []string {
 	return lines
 }
 
+func writerTTY(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	return ok && term.IsTerminal(int(f.Fd()))
+}
+
+func (cp *CollectionProgress) enterAltScreen() {
+	if !cp.useAltScreen || cp.onAltScreen {
+		return
+	}
+	fmt.Fprint(cp.display, "\033[?1049h\033[H\033[2J")
+	cp.onAltScreen = true
+	cp.initialized = false
+	cp.linesOnScreen = 0
+}
+
+func (cp *CollectionProgress) leaveAltScreen(hint string) {
+	if cp.onAltScreen {
+		fmt.Fprint(cp.display, "\033[?1049l")
+		cp.onAltScreen = false
+		cp.initialized = false
+		cp.linesOnScreen = 0
+	}
+	if hint != "" {
+		fmt.Fprintln(cp.display, cp.ui.dim("  "+hint))
+	}
+}
+
 func (cp *CollectionProgress) writeProgress() {
-	if !cp.ui.isTTY() {
+	if !writerTTY(cp.display) {
+		return
+	}
+	if cp.useAltScreen && !cp.onAltScreen {
 		return
 	}
 
 	cp.mu.Lock()
 	lines := cp.allLines()
+	prev := cp.linesOnScreen
 	cp.mu.Unlock()
 
 	if len(lines) == 0 {
@@ -468,22 +525,29 @@ func (cp *CollectionProgress) writeProgress() {
 	if !cp.initialized {
 		for i, line := range lines {
 			if i < len(lines)-1 {
-				cp.ui.println(line)
+				fmt.Fprintln(cp.display, line)
 			} else {
-				cp.ui.print(line)
+				fmt.Fprint(cp.display, line)
 			}
 		}
 		cp.initialized = true
+		cp.linesOnScreen = len(lines)
 		return
 	}
 
-	fmt.Fprintf(cp.ui.out, "\033[%dA", len(lines)-1)
+	if prev > 0 {
+		fmt.Fprintf(cp.display, "\033[%dA", prev)
+	}
 	for i, line := range lines {
 		if i > 0 {
-			fmt.Fprint(cp.ui.out, "\n")
+			fmt.Fprint(cp.display, "\n")
 		}
-		fmt.Fprintf(cp.ui.out, "\r\033[K%s", line)
+		fmt.Fprintf(cp.display, "\r\033[K%s", line)
 	}
+	for i := len(lines); i < prev; i++ {
+		fmt.Fprint(cp.display, "\n\033[K")
+	}
+	cp.linesOnScreen = len(lines)
 }
 
 // BeginNode marks which node is currently being collected.
@@ -512,8 +576,46 @@ func (cp *CollectionProgress) FinishNode() {
 	cp.writeProgress()
 }
 
+func sshHandoffMessage(ssh *SSHTarget) string {
+	if ssh == nil {
+		return "SSH/rsync — enter password or confirm host key if prompted"
+	}
+	if ssh.User == "" || ssh.Host == "" {
+		return "SSH/rsync — enter password or confirm host key if prompted"
+	}
+
+	node := strings.TrimSpace(ssh.MongoHost)
+	if node == "" {
+		node = ssh.Host
+	}
+	if ssh.MongoPort > 0 {
+		node = fmt.Sprintf("%s:%d", node, ssh.MongoPort)
+	}
+
+	purpose := strings.TrimSpace(ssh.Purpose)
+	if purpose != "" {
+		return fmt.Sprintf(
+			"SSH to %s@%s — copying %s for %s (enter password or confirm host key if prompted)",
+			ssh.User,
+			ssh.Host,
+			purpose,
+			node,
+		)
+	}
+	return fmt.Sprintf(
+		"SSH to %s@%s — enter password or confirm host key if prompted",
+		ssh.User,
+		ssh.Host,
+	)
+}
+
+func (cp *CollectionProgress) leaveForSubprocess(ssh *SSHTarget) {
+	cp.leaveAltScreen(sshHandoffMessage(ssh))
+}
+
 // RunTask runs a collection step and updates the global progress bar.
-func (cp *CollectionProgress) RunTask(taskIdx int, _ string, fn func() error) error {
+// Pass ssh when the task needs the main screen (e.g. SSH/rsync prompts).
+func (cp *CollectionProgress) RunTask(taskIdx int, ssh *SSHTarget, fn func() error) error {
 	cp.currentTaskIdx = taskIdx
 	cp.taskStart = time.Now()
 	cp.activeSpinner = true
@@ -521,7 +623,7 @@ func (cp *CollectionProgress) RunTask(taskIdx int, _ string, fn func() error) er
 	stop := make(chan struct{})
 	var wg sync.WaitGroup
 
-	if cp.ui.isTTY() {
+	if writerTTY(cp.display) && (!cp.useAltScreen || cp.onAltScreen) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -538,11 +640,24 @@ func (cp *CollectionProgress) RunTask(taskIdx int, _ string, fn func() error) er
 		}()
 	}
 
-	err := fn()
-	close(stop)
-	wg.Wait()
-	cp.activeSpinner = false
+	cp.writeProgress()
 
+	if ssh != nil {
+		close(stop)
+		wg.Wait()
+		cp.leaveForSubprocess(ssh)
+	}
+
+	err := fn()
+
+	if ssh != nil {
+		cp.enterAltScreen()
+	} else {
+		close(stop)
+		wg.Wait()
+	}
+
+	cp.activeSpinner = false
 	if err != nil {
 		cp.mu.Lock()
 		cp.nodeFailed = true
@@ -562,19 +677,28 @@ func (cp *CollectionProgress) SkipTask(taskIdx int, _, _ string) {
 	cp.writeProgress()
 }
 
-// Finish completes the progress bar and moves to the next output line.
+// Finish completes the progress bar and prints the final node list on the main screen.
 func (cp *CollectionProgress) Finish() {
 	cp.mu.Lock()
 	cp.activeSpinner = false
 	cp.tasksDone = cp.totalTasks
+	summary := cp.allLines()
 	cp.mu.Unlock()
 
-	if cp.ui.isTTY() {
-		cp.writeProgress()
-		cp.ui.println("")
+	activeCollectionProgress = nil
+	cp.leaveAltScreen("")
+
+	if !writerTTY(cp.display) {
+		if len(summary) > 0 {
+			fmt.Fprintln(cp.display, summary[0])
+		}
 		return
 	}
-	cp.ui.println(cp.barLine())
+
+	for _, line := range summary {
+		fmt.Fprintln(cp.display, line)
+	}
+	fmt.Fprintln(cp.display)
 }
 
 func (u *UI) isTTY() bool {
@@ -593,9 +717,5 @@ func (u *UI) clearLine() {
 // CollectionTaskSkipped is a no-op; collection progress is shown only via CollectionProgress.
 func (u *UI) CollectionTaskSkipped(_, _ int, _, _ string) {}
 
-// SSHAuthNotice tells the user to enter an SSH password when rsync prompts for it.
-func SSHAuthNotice() {
-	ui := NewDefault()
-	ui.Section("SSH authentication")
-	ui.Note("Enter your SSH password when rsync prompts for it.")
-}
+// SSHAuthNotice is a no-op; RunTask leaves the progress view before SSH/rsync subprocesses.
+func SSHAuthNotice() {}

--- a/termui/termui_test.go
+++ b/termui/termui_test.go
@@ -1,0 +1,240 @@
+// Copyright 2023 MongoDB Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package termui
+
+import (
+	"strings"
+	"testing"
+)
+
+func makeProgress(hosts []CollectionHost, tasksPerNode int) *CollectionProgress {
+	nodes := make([]collectionNodeStatus, len(hosts))
+	for i, h := range hosts {
+		nodes[i] = collectionNodeStatus{host: h, state: nodePending}
+	}
+	return &CollectionProgress{
+		ui:         New(strings.NewReader(""), &strings.Builder{}),
+		nodes:      nodes,
+		totalTasks: len(hosts) * tasksPerNode,
+		compact:    len(hosts) > progressCompactNodeThreshold,
+	}
+}
+
+func TestProgressLinesCompactLargeCluster(t *testing.T) {
+	// 9 shards × 3 members + 3 mongos + 9 config ≈ 39 nodes (typical large sharded scope).
+	hosts := make([]CollectionHost, 39)
+	for i := range hosts {
+		hosts[i] = CollectionHost{Hostname: "shard-mongo", Port: 27017 + i}
+	}
+	cp := makeProgress(hosts, 3)
+	if !cp.compact {
+		t.Fatal("expected compact mode for 39-node cluster")
+	}
+
+	cp.BeginNode(0)
+	lines := cp.progressLines()
+	if len(lines) != 1 {
+		t.Fatalf("compact live view should be 1 line (bar + active + counter), got %d", len(lines))
+	}
+	if !strings.Contains(lines[0], "›") {
+		t.Fatalf("expected active node marker, got %q", lines[0])
+	}
+	if !strings.Contains(lines[0], "0/39 nodes") {
+		t.Fatalf("expected node counter, got %q", lines[0])
+	}
+}
+
+func TestProgressLinesSmallCluster(t *testing.T) {
+	hosts := []CollectionHost{
+		{Hostname: "mongo1", Port: 27017},
+		{Hostname: "mongo2", Port: 27017},
+		{Hostname: "mongo3", Port: 27017},
+	}
+	cp := makeProgress(hosts, 3)
+	if cp.compact {
+		t.Fatal("expected full node list for 3-node cluster")
+	}
+	cp.BeginNode(0)
+	lines := cp.progressLines()
+	if len(lines) != 1 {
+		t.Fatalf("expected one-line live progress, got %d lines", len(lines))
+	}
+	if !strings.Contains(lines[0], "› mongo1:27017") {
+		t.Fatalf("expected active node in progress line, got %q", lines[0])
+	}
+	if !strings.Contains(lines[0], "0/3 nodes") {
+		t.Fatalf("expected node counter in progress line, got %q", lines[0])
+	}
+}
+
+func TestSummaryLinesCompactShowsBarOnly(t *testing.T) {
+	hosts := make([]CollectionHost, 10)
+	for i := range hosts {
+		hosts[i] = CollectionHost{Hostname: "node", Port: 27017 + i}
+	}
+	cp := makeProgress(hosts, 3)
+
+	summary := cp.summaryLines()
+	if len(summary) != 1 {
+		t.Fatalf("compact summary should be bar only, got %d lines", len(summary))
+	}
+	if !strings.Contains(summary[0], "%") {
+		t.Fatalf("expected progress bar, got %q", summary[0])
+	}
+}
+
+func TestNodeResultLineShowsTaskOutcomes(t *testing.T) {
+	cp := makeProgress([]CollectionHost{{Hostname: "mongo1", Port: 27017}}, 3)
+	cp.nodes[0].state = nodePartial
+	cp.nodes[0].tasks[0] = taskStatus{outcome: taskOK}
+	cp.nodes[0].tasks[1] = taskStatus{outcome: taskSkipped}
+	cp.nodes[0].tasks[2] = taskStatus{outcome: taskSkipped}
+
+	line := cp.nodeResultLine(0)
+	for _, want := range []string{"mongo1:27017", "getMongoData", "FTDC", "logs"} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("expected %q in result line, got %q", want, line)
+		}
+	}
+}
+
+func TestDeriveNodeState(t *testing.T) {
+	cp := makeProgress([]CollectionHost{{Hostname: "a", Port: 1}}, 3)
+	cp.nodes[0].tasks[0] = taskStatus{outcome: taskOK}
+	cp.nodes[0].tasks[1] = taskStatus{outcome: taskSkipped}
+	if got := cp.deriveNodeState(0); got != nodePartial {
+		t.Fatalf("expected partial, got %v", got)
+	}
+	cp.nodes[0].tasks[1] = taskStatus{outcome: taskFailed}
+	if got := cp.deriveNodeState(0); got != nodeFailed {
+		t.Fatalf("expected failed, got %v", got)
+	}
+}
+
+func TestWriteProgressLineStaysOnSameLine(t *testing.T) {
+	var buf strings.Builder
+	cp := makeProgress([]CollectionHost{{Hostname: "mongo1", Port: 27017}}, 3)
+	cp.display = &buf
+
+	cp.writeProgressLine("  bar   0%")
+	cp.writeProgressLine("  bar  50%")
+	cp.writeProgressLine("  bar 100%")
+
+	out := buf.String()
+	if strings.Count(out, "\n") != 1 {
+		t.Fatalf("expected a single reserved SSH slot newline, got %q", out)
+	}
+	if strings.Count(out, "\r") < 3 {
+		t.Fatalf("expected carriage-return bar updates, got %q", out)
+	}
+}
+
+func TestFitLinePreventsWrap(t *testing.T) {
+	long := "  " + strings.Repeat("█", 32) + "  100%  › shard01-mongo1.internal:27017  54/55 nodes"
+	got := fitLine(long, 40)
+	if visibleLen(got) > 40 {
+		t.Fatalf("fitLine exceeded width: %d > 40 (%q)", visibleLen(got), got)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("expected truncated line with ellipsis, got %q", got)
+	}
+}
+
+func TestSSHHandoffAppearsBelowBar(t *testing.T) {
+	var buf strings.Builder
+	cp := makeProgress([]CollectionHost{{Hostname: "mongo1", Port: 27017}}, 3)
+	cp.display = &buf
+
+	cp.writeProgressLine("  bar  10%")
+	cp.handoffForSubprocess(&SSHTarget{
+		User:      "ubuntu",
+		Host:      "mongo1",
+		Purpose:   "FTDC data",
+		MongoHost: "mongo1",
+		MongoPort: 27017,
+	})
+
+	out := buf.String()
+	barAt := strings.Index(out, "bar  10%")
+	nlAt := strings.Index(out, "\n")
+	sshAt := strings.Index(out, "ubuntu@mongo1")
+	if barAt < 0 || nlAt < 0 || sshAt < 0 {
+		t.Fatalf("expected bar, newline, and SSH hint, got %q", out)
+	}
+	if !(barAt < nlAt && nlAt < sshAt) {
+		t.Fatalf("SSH hint must print below the bar, got %q", out)
+	}
+	if !cp.onHintLine {
+		t.Fatal("expected cursor on the SSH hint row")
+	}
+}
+
+func TestSSHHintReusesSameLine(t *testing.T) {
+	var buf strings.Builder
+	cp := makeProgress([]CollectionHost{{Hostname: "mongo1", Port: 27017}}, 3)
+	cp.display = &buf
+	ssh := &SSHTarget{
+		User: "ubuntu", Host: "mongo1", Purpose: "FTDC data",
+		MongoHost: "mongo1", MongoPort: 27017,
+	}
+
+	cp.writeProgressLine("  bar  10%")
+	cp.handoffForSubprocess(ssh)
+	ssh.Purpose = "mongod logs"
+	cp.handoffForSubprocess(ssh)
+
+	out := buf.String()
+	if strings.Count(out, "\n") != 2 {
+		t.Fatalf("SSH hints must overwrite one slot under the bar, got %d newlines in %q", strings.Count(out, "\n"), out)
+	}
+	if !strings.Contains(out, "mongod logs") {
+		t.Fatalf("expected second hint to replace the first, got %q", out)
+	}
+}
+
+func TestReconcileReturnsToBar(t *testing.T) {
+	var buf strings.Builder
+	cp := makeProgress([]CollectionHost{{Hostname: "mongo1", Port: 27017}}, 3)
+	cp.display = &buf
+
+	cp.writeProgressLine("  bar  10%")
+	cp.handoffForSubprocess(&SSHTarget{
+		User: "ubuntu", Host: "mongo1", Purpose: "FTDC data",
+		MongoHost: "mongo1", MongoPort: 27017,
+	})
+	cp.reconcileAfterSubprocess()
+	cp.writeProgressLine("  bar  20%")
+
+	out := buf.String()
+	if !strings.Contains(out, "\033[1A") {
+		t.Fatalf("expected return to bar after SSH, got %q", out)
+	}
+	if cp.onHintLine {
+		t.Fatal("cursor should be back on the bar after reconcile")
+	}
+}
+
+func TestSSHHandoffMessageIncludesPurpose(t *testing.T) {
+	msg := sshHandoffMessage(&SSHTarget{
+		User:      "ubuntu",
+		Host:      "mongo1",
+		Purpose:   "FTDC data",
+		MongoHost: "mongo1",
+		MongoPort: 27017,
+	})
+	if !strings.Contains(msg, "FTDC data") || !strings.Contains(msg, "ubuntu@mongo1") {
+		t.Fatalf("unexpected handoff message: %q", msg)
+	}
+}


### PR DESCRIPTION
## Summary

Improves **dcrcli** interactive prompts and terminal UX based on demo feedback, without changing collection behavior or weakening existing security controls.

## What changed

### Shared terminal UI (`termui/`)
- New package for consistent prompts, headers, steps, tips, warnings, and styled output
- Same-line input (`›`) for cluster setup prompts
- Live **collection progress**: one global `%` progress bar + one fixed line per target node
  - `·` pending → `›` collecting → `✓` done / `!` failed
  - Updates in place (no terminal flooding)

Using config, minimal interaction:
<img width="722" height="750" alt="image" src="https://github.com/user-attachments/assets/f2175102-5d9f-4111-bed1-06a6a0f42bf4" />

interactive prompts:
<img width="949" height="1172" alt="image" src="https://github.com/user-attachments/assets/ff191780-fd94-4d81-b119-22e7552c0f8e" />






### Connection setup prompts (`mongocredentials/`, `fscopy/`)
- Clearer 7-step flow: cluster name, seed host/port, MongoDB username/password, URI options, SSH username
- Seed explained as cluster entry point (hello / getShardMap discovery)
- Shorter, plainer help text for seed and SSH
- Blank MongoDB password → `No MongoDB password; assuming cluster without authentication`
- SSH prompt clarified: only for FTDC/log copy on remote machines

### Collection scope (`collectnodes/`, `main.go`)
- Separate **Collection scope** section (after connection setup)
- Topology discovery runs under that section before the scope menu
- Clearer option selection with spacing and `Selected option N — …` confirmation
- Spinner only during topology discovery

### Orchestration (`main.go`)
- Refactored collection loop to use `CollectionProgress`
- Remote nodes without SSH user: getMongoData still runs; FTDC/logs skipped with warning
- Existing health gates and free-space checks preserved

### Docs (`README.md`, `dcrconfig/`)
- Config/README clarifies seed host, password prompting, and SSH username purpose
- Removed misleading implication that MongoDB password belongs in config

## Security

- **No regressions** vs approved baseline: passwords still not stored in config, echo disabled via `term.ReadPassword`, 16MB input limits and URI validation unchanged, rsync/SSH behavior unchanged
- Minor improvement: clearer docs that password is never stored in config

## Test plan

- [ ] `go build -o dcrcli .`
- [ ] ./dcrcli
- [ ] Interactive run without `-config` (all 7 connection steps + collection scope)
- [ ] Multi-node local cluster, option 3: progress bar + all nodes shown with correct status icons
- [ ] `-config` path: config summary + password prompt when username set
- [ ] `-generate-config dcrcli.config.json`
- [ ] Remote node, no SSH user: getMongoData succeeds; FTDC/logs skipped

